### PR TITLE
Use user defined key instead of always using file hash as a cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Client can be used for creating, resuming and/or deleting uploads.
 ```php
 $client = new \TusPhp\Tus\Client($baseUrl, 'redis'); // Leave second parameter empty for file based cache
 
-$client->file('/path/to/file', 'filename.ext');
+$key = 'your unique key';
+
+$client->setKey($key)->file('/path/to/file', 'filename.ext');
 
 // Create and upload a chunk of 1mb
 $bytesUploaded = $client->upload(1000000); 
@@ -69,9 +71,7 @@ $offset = $client->getOffset(); // 2000000 bytes or 2mb
 Delete partial upload from cache.
 
 ```php
-$checksum = $client->getChecksum();
-
-$client->delete($checksum);
+$client->delete($key);
 ```
 
 By default the client uses `/files` as a api path. You can change it with `setApiPath` method.
@@ -122,18 +122,18 @@ $checksum = $client->getChecksum();
 
 // Upload 10000 bytes starting from 1000 bytes
 $bytesUploaded = $client->seek(1000)->upload(10000);
-$chunkAchecksum  = $client->getChecksum();
+$chunkAkey     = $client->getKey();
 
 // Upload 1000 bytes starting from 0 bytes
 $bytesUploaded = $client->setFileName('chunk_b.ext')->seek(0)->upload(1000);
-$chunkBchecksum = $client->getChecksum();
+$chunkBkey     = $client->getKey();
 
 // Upload remaining bytes starting from 11000 bytes (10000 +  1000)
 $bytesUploaded = $client->setFileName('chunk_c.ext')->seek(11000)->upload();
-$chunkCchecksum = $client->getChecksum();
+$chunkCkey     = $client->getKey();
 
 // Concatenate partial uploads
-$client->setFileName('actual_file.ext')->concat($checksum, $chunkAchecksum, $chunkBchecksum, $chunkCchecksum);
+$client->setFileName('actual_file.ext')->concat($checksum, $chunkAkey, $chunkBkey, $chunkCkey);
 ```
 
 Additionally, the server will verify checksum against the merged file to make sure that the file is not corrupt.  

--- a/example/partial.php
+++ b/example/partial.php
@@ -10,24 +10,24 @@ $client = new \TusPhp\Tus\Client('http://tus-php-server', 'redis');
 
 if ( ! empty($_FILES)) {
     $fileMeta = $_FILES['tus_file'];
+    $checksum = hash_file('md5', $fileMeta['tmp_name']);
 
     try {
-        $client->file($fileMeta['tmp_name'], 'chunk_a');
-        $checksum = $client->getChecksum();
+        $client->setKey($checksum)->file($fileMeta['tmp_name'], 'chunk_a');
 
         // Upload  10000 bytes starting from 1000 byte
         $bytesUploaded = $client->seek(1000)->upload(10000);
-        $partialChunk1 = $client->getChecksum();
+        $partialKey1   = $client->getKey();
 
         // Upload first 1000 bytes
         $bytesUploaded = $client->setFileName('chunk_b')->seek(0)->upload(1000);
-        $partialChunk2 = $client->getChecksum();
+        $partialKey2   = $client->getKey();
 
         // Upload remaining bytes starting from 11000 bytes (10000 + 1000)
         $bytesUploaded = $client->setFileName('chunk_c')->seek(11000)->upload();
-        $partialChunk3 = $client->getChecksum();
+        $partialKey3   = $client->getKey();
 
-        $client->setFileName($fileMeta['name'])->concat($checksum, $partialChunk2, $partialChunk1, $partialChunk3);
+        $client->setFileName($fileMeta['name'])->concat($checksum, $partialKey2, $partialKey1, $partialKey3);
 
         echo json_encode([
             'status' => 'uploading',

--- a/example/upload.php
+++ b/example/upload.php
@@ -13,18 +13,18 @@ use TusPhp\Exception\Exception as TusException;
 $client = new \TusPhp\Tus\Client('http://tus-php-server', 'redis');
 
 if ( ! empty($_FILES)) {
-    $fileMeta = $_FILES['tus_file'];
-    $checksum = hash_file('md5', $fileMeta['tmp_name']);
+    $fileMeta  = $_FILES['tus_file'];
+    $uploadKey = hash_file('md5', $fileMeta['tmp_name']);
 
     try {
-        $client->setKey($checksum)->file($fileMeta['tmp_name'], time() . '_' . $fileMeta['name']);
+        $client->setKey($uploadKey)->file($fileMeta['tmp_name'], time() . '_' . $fileMeta['name']);
 
         $bytesUploaded = $client->upload(5000000); // Chunk of 5 mb
 
         echo json_encode([
             'status' => 'uploading',
             'bytes_uploaded' => $bytesUploaded,
-            'checksum' => $checksum,
+            'checksum' => $client->getChecksum(),
         ]);
     } catch (ConnectionException | FileException | TusException $e) {
         echo json_encode([

--- a/example/upload.php
+++ b/example/upload.php
@@ -14,11 +14,10 @@ $client = new \TusPhp\Tus\Client('http://tus-php-server', 'redis');
 
 if ( ! empty($_FILES)) {
     $fileMeta = $_FILES['tus_file'];
+    $checksum = hash_file('md5', $fileMeta['tmp_name']);
 
     try {
-        $client->file($fileMeta['tmp_name'], time() . '_' . $fileMeta['name']);
-
-        $checksum = $client->getChecksum();
+        $client->setKey($checksum)->file($fileMeta['tmp_name'], time() . '_' . $fileMeta['name']);
 
         $bytesUploaded = $client->upload(5000000); // Chunk of 5 mb
 
@@ -39,6 +38,6 @@ if ( ! empty($_FILES)) {
     echo json_encode([
         'status' => 'error',
         'bytes_uploaded' => -1,
-        'error' => 'No input!'
+        'error' => 'No input!',
     ]);
 }

--- a/example/verify.php
+++ b/example/verify.php
@@ -16,10 +16,10 @@ $client = new \TusPhp\Tus\Client('http://tus-php-server', 'redis');
 if ( ! empty($_FILES)) {
     $status   = 'new';
     $fileMeta = $_FILES['tus_file'];
-    $checksum = hash_file('md5', $fileMeta['tmp_name']);
+    $uploadKey = hash_file('md5', $fileMeta['tmp_name']);
 
     try {
-        $offset = $client->setKey($checksum)->file($fileMeta['tmp_name'])->getOffset();
+        $offset = $client->setKey($uploadKey)->file($fileMeta['tmp_name'])->getOffset();
 
         if (false !== $offset) {
             $status = $offset >= $fileMeta['size'] ? 'uploaded' : 'resume';
@@ -30,7 +30,7 @@ if ( ! empty($_FILES)) {
         echo json_encode([
             'status' => $status,
             'bytes_uploaded' => $offset,
-            'checksum' => $checksum,
+            'checksum' => $client->getChecksum(),
         ]);
     } catch (ConnectionException | ConnectException $e) {
         echo json_encode([

--- a/example/verify.php
+++ b/example/verify.php
@@ -16,10 +16,10 @@ $client = new \TusPhp\Tus\Client('http://tus-php-server', 'redis');
 if ( ! empty($_FILES)) {
     $status   = 'new';
     $fileMeta = $_FILES['tus_file'];
+    $checksum = hash_file('md5', $fileMeta['tmp_name']);
 
     try {
-        $offset   = $client->file($fileMeta['tmp_name'])->getOffset();
-        $checksum = $client->getChecksum();
+        $offset = $client->setKey($checksum)->file($fileMeta['tmp_name'])->getOffset();
 
         if (false !== $offset) {
             $status = $offset >= $fileMeta['size'] ? 'uploaded' : 'resume';

--- a/src/File.php
+++ b/src/File.php
@@ -23,6 +23,9 @@ class File
     const APPEND_BINARY = 'ab+';
 
     /** @var string */
+    protected $key;
+
+    /** @var string */
     protected $checksum;
 
     /** @var string */
@@ -121,6 +124,30 @@ class File
     public function getFileSize() : int
     {
         return $this->fileSize;
+    }
+
+    /**
+     * Set key.
+     *
+     * @param string $key
+     *
+     * @return File
+     */
+    public function setKey(string $key) : self
+    {
+        $this->key = $key;
+
+        return $this;
+    }
+
+    /**
+     * Get key.
+     *
+     * @return string
+     */
+    public function getKey() : string
+    {
+        return $this->key;
     }
 
     /**
@@ -242,6 +269,7 @@ class File
             'name' => $this->name,
             'size' => $this->fileSize,
             'offset' => $this->offset,
+            'checksum' => $this->checksum,
             'location' => $this->location,
             'file_path' => $this->filePath,
             'created_at' => $now->format($this->cache::RFC_7231),
@@ -266,9 +294,9 @@ class File
             return $bytesWritten;
         }
 
-        $input    = $this->open($this->getInputStream(), self::READ_BINARY);
-        $output   = $this->open($this->getFilePath(), self::APPEND_BINARY);
-        $checksum = $this->getChecksum();
+        $input  = $this->open($this->getInputStream(), self::READ_BINARY);
+        $output = $this->open($this->getFilePath(), self::APPEND_BINARY);
+        $key    = $this->getKey();
 
         try {
             $this->seek($output, $bytesWritten);
@@ -283,7 +311,7 @@ class File
 
                 $bytesWritten += $bytes;
 
-                $this->cache->set($checksum, ['offset' => $bytesWritten]);
+                $this->cache->set($key, ['offset' => $bytesWritten]);
 
                 if ($bytesWritten > $totalBytes) {
                     throw new OutOfRangeException('The uploaded file is corrupt.');

--- a/src/Request.php
+++ b/src/Request.php
@@ -30,9 +30,11 @@ class Request
     }
 
     /**
+     * Get upload key from url.
+     *
      * @return null|string
      */
-    public function checksum()
+    public function key()
     {
         return $this->request->segment(2);
     }

--- a/src/Tus/Server.php
+++ b/src/Tus/Server.php
@@ -336,9 +336,7 @@ class Server extends AbstractTus
 
         try {
             $fileSize = $file->getFileSize();
-            $offset   = $file->setKey($uploadKey)
-                             ->setChecksum($checksum)
-                             ->upload($fileSize);
+            $offset   = $file->setKey($uploadKey)->setChecksum($checksum)->upload($fileSize);
 
             // If upload is done, verify checksum.
             if ($offset === $fileSize && $checksum !== $this->getServerChecksum($meta['file_path'])) {

--- a/tests/FileTest.php
+++ b/tests/FileTest.php
@@ -596,21 +596,21 @@ class FileTest extends TestCase
      */
     public function it_throws_connection_exception_if_connection_is_aborted_by_user()
     {
-        $file     = __DIR__ . '/.tmp/upload.txt';
-        $checksum = '74f02d6da32082463e382f2274e85fd8eae3e81f739f8959abc91865656e3b3a';
+        $file = __DIR__ . '/.tmp/upload.txt';
+        $key  = uniqid();
 
         $cacheMock = m::mock(FileStore::class);
         $fileMock  = m::mock(File::class, [null, $cacheMock])->makePartial();
 
         $fileMock
-            ->shouldReceive('getChecksum')
+            ->shouldReceive('getKey')
             ->once()
-            ->andReturn($checksum);
+            ->andReturn($key);
 
         $this->mockBuilder
             ->setName('connection_status')
             ->setFunction(
-                function () use ($checksum) {
+                function () use ($key) {
                     return 1;
                 }
             );
@@ -639,10 +639,10 @@ class FileTest extends TestCase
      */
     public function it_throws_exception_if_uploaded_file_is_corrupt()
     {
-        $file       = __DIR__ . '/.tmp/upload.txt';
-        $data       = file_get_contents(__DIR__ . '/Fixtures/data.txt');
-        $checksum   = '74f02d6da32082463e382f2274e85fd8eae3e81f739f8959abc91865656e3b3a';
-        $totalBytes = strlen($data);
+        $file  = __DIR__ . '/.tmp/upload.txt';
+        $data  = file_get_contents(__DIR__ . '/Fixtures/data.txt');
+        $key   = uniqid();
+        $bytes = strlen($data);
 
         $cacheMock = m::mock(FileStore::class);
         $fileMock  = m::mock(File::class, [null, $cacheMock])->makePartial();
@@ -653,20 +653,20 @@ class FileTest extends TestCase
             ->andReturn($data);
 
         $fileMock
-            ->shouldReceive('getChecksum')
+            ->shouldReceive('getKey')
             ->once()
-            ->andReturn($checksum);
+            ->andReturn($key);
 
         $cacheMock
             ->shouldReceive('set')
             ->once()
-            ->with($checksum, ['offset' => $totalBytes])
+            ->with($key, ['offset' => $bytes])
             ->andReturn(null);
 
         $fileMock
             ->setFilePath($file)
             ->setOffset(0)
-            ->upload($totalBytes - 1);
+            ->upload($bytes - 1);
 
         @unlink($file);
     }
@@ -682,6 +682,7 @@ class FileTest extends TestCase
     {
         $file       = __DIR__ . '/.tmp/upload.txt';
         $dataFile   = __DIR__ . '/Fixtures/large.txt';
+        $key        = uniqid();
         $checksum   = '74f02d6da32082463e382f2274e85fd8eae3e81f739f8959abc91865656e3b3a';
         $chunkSize  = 8192;
         $totalBytes = 17548;
@@ -695,26 +696,26 @@ class FileTest extends TestCase
             ->andReturn($dataFile);
 
         $fileMock
-            ->shouldReceive('getChecksum')
+            ->shouldReceive('getKey')
             ->once()
-            ->andReturn($checksum);
+            ->andReturn($key);
 
         $cacheMock
             ->shouldReceive('set')
             ->once()
-            ->with($checksum, ['offset' => $chunkSize])
+            ->with($key, ['offset' => $chunkSize])
             ->andReturn(null);
 
         $cacheMock
             ->shouldReceive('set')
             ->once()
-            ->with($checksum, ['offset' => $chunkSize * 2])
+            ->with($key, ['offset' => $chunkSize * 2])
             ->andReturn(null);
 
         $cacheMock
             ->shouldReceive('set')
             ->once()
-            ->with($checksum, ['offset' => $totalBytes])
+            ->with($key, ['offset' => $totalBytes])
             ->andReturn(null);
 
         $this->mockBuilder
@@ -752,6 +753,7 @@ class FileTest extends TestCase
     {
         $file       = __DIR__ . '/.tmp/upload.txt';
         $data       = file_get_contents(__DIR__ . '/Fixtures/data.txt');
+        $key        = uniqid();
         $checksum   = '74f02d6da32082463e382f2274e85fd8eae3e81f739f8959abc91865656e3b3a';
         $totalBytes = strlen($data);
 
@@ -764,14 +766,14 @@ class FileTest extends TestCase
             ->andReturn($data);
 
         $fileMock
-            ->shouldReceive('getChecksum')
+            ->shouldReceive('getKey')
             ->once()
-            ->andReturn($checksum);
+            ->andReturn($key);
 
         $cacheMock
             ->shouldReceive('set')
             ->once()
-            ->with($checksum, ['offset' => $totalBytes])
+            ->with($key, ['offset' => $totalBytes])
             ->andReturn(null);
 
         $this->mockBuilder

--- a/tests/FileTest.php
+++ b/tests/FileTest.php
@@ -30,8 +30,7 @@ class FileTest extends TestCase
     {
         $this->file = new File('tus.txt', CacheFactory::make());
 
-        $this->file->setMeta(100, 1024, '/path/to/file.txt', 'http://tus.local/uploads/file.txt');
-
+        $this->assertInstanceOf(File::class, $this->file->setMeta(100, 1024, '/path/to/file.txt', 'http://tus.local/uploads/file.txt'));
         $this->mockBuilder = (new MockBuilder)->setNamespace('\TusPhp');
     }
 
@@ -67,8 +66,7 @@ class FileTest extends TestCase
     {
         $this->assertEquals('tus.txt', $this->file->getName());
 
-        $this->file->setName('file.txt');
-
+        $this->assertInstanceOf(File::class, $this->file->setName('file.txt'));
         $this->assertEquals('file.txt', $this->file->getName());
     }
 
@@ -82,8 +80,7 @@ class FileTest extends TestCase
     {
         $this->assertEquals(1024, $this->file->getFileSize());
 
-        $this->file->setFileSize(2056);
-
+        $this->assertInstanceOf(File::class, $this->file->setFileSize(2056));
         $this->assertEquals(2056, $this->file->getFileSize());
     }
 
@@ -97,9 +94,22 @@ class FileTest extends TestCase
     {
         $checksum = '74f02d6da32082463e382f2274e85fd8eae3e81f739f8959abc91865656e3b3a';
 
-        $this->file->setChecksum($checksum);
-
+        $this->assertInstanceOf(File::class, $this->file->setChecksum($checksum));
         $this->assertEquals($checksum, $this->file->getChecksum());
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::setKey
+     * @covers ::getKey
+     */
+    public function it_sets_and_gets_key()
+    {
+        $key = uniqid();
+
+        $this->assertInstanceOf(File::class, $this->file->setKey($key));
+        $this->assertEquals($key, $this->file->getKey());
     }
 
     /**
@@ -111,9 +121,7 @@ class FileTest extends TestCase
     public function it_sets_and_gets_offset()
     {
         $this->assertEquals(100, $this->file->getOffset());
-
-        $this->file->setOffset(500);
-
+        $this->assertInstanceOf(File::class, $this->file->setOffset(500));
         $this->assertEquals(500, $this->file->getOffset());
     }
 
@@ -129,8 +137,7 @@ class FileTest extends TestCase
 
         $location = 'http://tus.local/uploads/file.pdf';
 
-        $this->file->setLocation($location);
-
+        $this->assertInstanceOf(File::class, $this->file->setLocation($location));
         $this->assertEquals($location, $this->file->getLocation());
     }
 
@@ -146,8 +153,7 @@ class FileTest extends TestCase
 
         $filePath = '/path/to/file.pdf';
 
-        $this->file->setFilePath($filePath);
-
+        $this->assertInstanceOf(File::class, $this->file->setFilePath($filePath));
         $this->assertEquals($filePath, $this->file->getFilePath());
     }
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -46,7 +46,7 @@ class RequestTest extends TestCase
     /**
      * @test
      *
-     * @covers ::checksum
+     * @covers ::key
      */
     public function it_should_return_checksum_from_request_url()
     {
@@ -54,7 +54,7 @@ class RequestTest extends TestCase
 
         $this->request->getRequest()->server->set('REQUEST_URI', '/files/' . $checksum);
 
-        $this->assertEquals($checksum, $this->request->checksum());
+        $this->assertEquals($checksum, $this->request->key());
     }
 
     /**

--- a/tests/Tus/ClientTest.php
+++ b/tests/Tus/ClientTest.php
@@ -162,6 +162,20 @@ class ClientTest extends TestCase
     /**
      * @test
      *
+     * @covers ::setKey
+     * @covers ::getKey
+     */
+    public function it_sets_and_gets_key()
+    {
+        $key = uniqid();
+
+        $this->assertInstanceOf(TusClient::class, $this->tusClient->setKey($key));
+        $this->assertEquals($key, $this->tusClient->getKey());
+    }
+
+    /**
+     * @test
+     *
      * @covers ::setChecksumAlgorithm
      * @covers ::getChecksumAlgorithm
      */

--- a/tests/Tus/ServerTest.php
+++ b/tests/Tus/ServerTest.php
@@ -1876,7 +1876,7 @@ class ServerTest extends TestCase
      *
      * @covers ::getClientChecksum
      */
-    public function it_returns_404_for_invalid_checksum_in_header()
+    public function it_returns_400_for_invalid_checksum_in_header()
     {
         $mockBuilder = (new MockBuilder())->setNamespace('\TusPhp\Tus');
 
@@ -1923,6 +1923,37 @@ class ServerTest extends TestCase
             ->set('Upload-Checksum', 'sha1 ' . base64_encode($checksum));
 
         $this->assertEquals($checksum, $this->tusServerMock->getClientChecksum());
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::getUploadKey
+     */
+    public function it_returns_400_for_no_upload_key_in_header()
+    {
+        $response = $this->tusServerMock->getUploadKey();
+
+        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertNull($response->getOriginalContent());
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::getUploadKey
+     */
+    public function it_gets_upload_key_from_header()
+    {
+        $key = uniqid();
+
+        $this->tusServerMock
+            ->getRequest()
+            ->getRequest()
+            ->headers
+            ->set('Upload-Key', base64_encode($key));
+
+        $this->assertEquals($key, $this->tusServerMock->getUploadKey());
     }
 
     /**


### PR DESCRIPTION
- [x] Use user defined key instead of always using file hash as a cache key
- [x] Update all examples
- [x] Fix old tests
- [x] Add missing tests
- [x] Update README
- [x] Regression test

Fixes issue #17