### PR TITLE
Fix carbon dependency for laravel 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "predis/predis": "^1.1",
     "symfony/console": ">=3.4.11",
     "ramsey/uuid": "^3.7",
-    "nesbot/carbon": "^1.26"
+    "nesbot/carbon": "^1.25"
   },
   "require-dev": {
     "phpunit/phpunit": "6.5.x-dev",


### PR DESCRIPTION
Laravel's [dependency for nesbot/carbon was locked to 1.25](https://github.com/laravel/framework/commit/27b88449805c1e9903fe4088f303c0858336b23b) in v5.6.17 because of some breaking changes on nesbot/carbon@1.26.*