### PR TITLE
Ensure we find the filename in Upload-Metadata when clients send extra

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -123,15 +123,13 @@ class Request
             return null;
         }
 
-        if (false !== strpos($meta, ',')) {
-            $pieces = explode(',', $meta);
-
-            list(/* $key */, $file) = explode(' ', $pieces[0]);
-        } else {
-            list(/* $key */, $file) = explode(' ', $meta);
+        $pieces = explode(',', $meta);
+        foreach ($pieces as $piece) {
+          list($metaName, $metaValue) = explode(' ', $piece);
+          $metaValues[$metaName] = base64_decode($metaValue);
         }
 
-        return base64_decode($file);
+        return $metaValues['filename'];
     }
 
     /**


### PR DESCRIPTION
I wrote a Drupal integration (https://www.drupal.org/project/tus), and we need a few extra values passed from Uppy in the `meta{}` option.
entityType, entityBundle, fieldName (for determining folder storage based on user's settings within the CMS).

tus-php assumes a single value, or that the first value in the Upload-Metadata header is filename.
When I plug in the extra values in Uppy, filename occurs last, and tus-php fails to find filename properly.

This will fix that.