### PR TITLE
Refactor Upload-Metadata extract

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -113,25 +113,39 @@ class Request
     /**
      * Extract base64 encoded filename from header.
      *
-     * @return string|null
+     * @return string
      */
-    public function extractFileName() : ?string
+    public function extractFileName() : string
     {
-        $meta = $this->header('Upload-Metadata');
+        return $this->extractMeta('name') ?: $this->extractMeta('filename');
+    }
 
-        if (empty($meta)) {
-            return null;
+    /**
+     * Extracts the meta data from the request header.
+     *
+     * @param string $requestedKey
+     *
+     * @return string
+     */
+    public function extractMeta(string $requestedKey) : string
+    {
+        $uploadMetaData = $this->request->headers->get('Upload-Metadata');
+
+        if (empty($uploadMetaData)) {
+            return '';
         }
 
-        if (false !== strpos($meta, ',')) {
-            $pieces = explode(',', $meta);
+        $uploadMetaDataChunks = explode(',', $uploadMetaData);
 
-            list(/* $key */, $file) = explode(' ', $pieces[0]);
-        } else {
-            list(/* $key */, $file) = explode(' ', $meta);
+        foreach ($uploadMetaDataChunks as $chunk) {
+            list($key, $value) = explode(' ', $chunk);
+
+            if ($key === $requestedKey) {
+                return base64_decode($value);
+            }
         }
 
-        return base64_decode($file);
+        return '';
     }
 
     /**

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -127,11 +127,11 @@ class RequestTest extends TestCase
      */
     public function it_extracts_data_from_header()
     {
-        $this->request->getRequest()->headers->set('Upload-Metadata', 'filename test');
+        $this->request->getRequest()->headers->set('Upload-Metadata', 'filename dGVzdA==');
         $this->request->getRequest()->headers->set('Upload-Concat', 'final;/files/a /files/b');
 
         $this->assertEquals([], $this->request->extractFromHeader('Upload-Metadata', 'invalid'));
-        $this->assertEquals(['test'], $this->request->extractFromHeader('Upload-Metadata', 'filename'));
+        $this->assertEquals(['dGVzdA=='], $this->request->extractFromHeader('Upload-Metadata', 'filename'));
         $this->assertEquals(['/files/a', '/files/b'], $this->request->extractFromHeader('Upload-Concat', 'final;'));
     }
 
@@ -146,23 +146,6 @@ class RequestTest extends TestCase
         $filename = 'file.txt';
 
         $this->request->getRequest()->headers->set('Upload-Metadata', 'name ' . base64_encode($filename));
-        $this->assertEquals($filename, $this->request->extractFileName());
-    }
-
-    /**
-     * @test
-     *
-     * @covers ::extractMeta
-     * @covers ::extractFileName
-     */
-    public function it_extracts_file_name_from_concatenated_headers()
-    {
-        $filename = 'file.txt';
-
-        $this->request
-            ->getRequest()
-            ->headers
-            ->set('Upload-Metadata', 'filename ' . base64_encode($filename) . ',type image');
 
         $this->assertEquals($filename, $this->request->extractFileName());
     }
@@ -185,7 +168,7 @@ class RequestTest extends TestCase
             ->set(
                 'Upload-Metadata',
                 sprintf(
-                    'name %s,type %s,accept %s',
+                    'filename %s,type %s,accept %s',
                     base64_encode($filename),
                     base64_encode($fileType),
                     base64_encode($accept)
@@ -200,7 +183,7 @@ class RequestTest extends TestCase
     /**
      * @test
      *
-     * d@covers ::extractMeta
+     * @covers ::extractMeta
      */
     public function it_returns_empty_if_upload_metadata_header_not_present()
     {

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -123,16 +123,6 @@ class RequestTest extends TestCase
     /**
      * @test
      *
-     * @covers ::extractFileName
-     */
-    public function it_return_null_if_it_cannot_extract_filename()
-    {
-        $this->assertNull($this->request->extractFileName());
-    }
-
-    /**
-     * @test
-     *
      * @covers ::extractFromHeader
      */
     public function it_extracts_data_from_header()
@@ -148,21 +138,21 @@ class RequestTest extends TestCase
     /**
      * @test
      *
-     * @covers ::extractFromHeader
+     * @covers ::extractMeta
      * @covers ::extractFileName
      */
     public function it_extracts_file_name()
     {
         $filename = 'file.txt';
 
-        $this->request->getRequest()->headers->set('Upload-Metadata', 'filename ' . base64_encode($filename));
-
+        $this->request->getRequest()->headers->set('Upload-Metadata', 'name ' . base64_encode($filename));
         $this->assertEquals($filename, $this->request->extractFileName());
     }
 
     /**
      * @test
      *
+     * @covers ::extractMeta
      * @covers ::extractFileName
      */
     public function it_extracts_file_name_from_concatenated_headers()
@@ -180,18 +170,48 @@ class RequestTest extends TestCase
     /**
      * @test
      *
+     * @covers ::extractMeta
      * @covers ::extractFileName
      */
-    public function it_extracts_file_name_from_multiple_concatenated_headers()
+    public function it_extracts_metadata_from_multiple_concatenated_headers()
     {
         $filename = 'file.txt';
+        $fileType = 'image';
+        $accept   = 'image/jpeg';
 
         $this->request
             ->getRequest()
             ->headers
-            ->set('Upload-Metadata', 'name ' . base64_encode($filename) . ',type image,accept jpeg');
+            ->set(
+                'Upload-Metadata',
+                sprintf(
+                    'name %s,type %s,accept %s',
+                    base64_encode($filename),
+                    base64_encode($fileType),
+                    base64_encode($accept)
+                )
+            );
 
         $this->assertEquals($filename, $this->request->extractFileName());
+        $this->assertEquals($fileType, $this->request->extractMeta('type'));
+        $this->assertEquals($accept, $this->request->extractMeta('accept'));
+    }
+
+    /**
+     * @test
+     *
+     * d@covers ::extractMeta
+     */
+    public function it_returns_empty_if_upload_metadata_header_not_present()
+    {
+        $this->assertEmpty($this->request->extractMeta('invalid-key'));
+
+        $this->request
+            ->getRequest()
+            ->headers
+            ->set('Upload-Metadata', '');
+
+        $this->assertEmpty($this->request->extractMeta('invalid-key'));
     }
 
     /**


### PR DESCRIPTION
Related to https://github.com/ankitpokhrel/tus-php/pull/82

This PR addresses the issue when Upload-Metadata has multiple metadata separated with commas as per [Tus Protocol for Upload-Metadata](https://tus.io/protocols/resumable-upload.html#upload-metadata)