### PR TITLE
fix the broken download link in example link

### DIFF
--- a/example/basic/index.php
+++ b/example/basic/index.php
@@ -229,10 +229,10 @@
           bytesUploaded = data;
 
           renderProgressBar(bytesUploaded, fileSize);
-        }, function (checksum) {
+        }, function (uploadKey) {
           cleanUp();
 
-          listUploadedFiles(fileMeta, checksum);
+          listUploadedFiles(fileMeta, uploadKey);
         });
       });
     });
@@ -260,7 +260,7 @@
         if ('uploaded' === response.status) {
           cleanUp();
 
-          listUploadedFiles(fileMeta, response.checksum)
+          listUploadedFiles(fileMeta, response.upload_key)
         } else if ('error' !== response.status) {
           cb();
         }
@@ -300,7 +300,7 @@
         if (bytesUploaded < fileSize) {
           upload(formData, fileSize, cb, onComplete);
         } else {
-          onComplete(response.checksum);
+          onComplete(response.upload_key);
         }
       },
       error: function (error) {
@@ -322,13 +322,13 @@
     $('#tus-file').attr('disabled', false);
   };
 
-  var listUploadedFiles = function (fileMeta, checksum) {
+  var listUploadedFiles = function (fileMeta, uploadKey) {
     var completedUploads = $('div.completed-uploads');
 
     completedUploads.find('p.info').remove();
     completedUploads.append(
       '<div class="panel panel-default"><div class="panel-body"><a href="<?= (string) (getenv('SERVER_URL') ?? '') ?>/files/'
-      + checksum + '">' + fileMeta.name + '</a> (' + fileMeta.size + ' bytes)</div></div>'
+      + uploadKey + '">' + fileMeta.name + '</a> (' + fileMeta.size + ' bytes)</div></div>'
     );
   };
 

--- a/example/basic/upload.php
+++ b/example/basic/upload.php
@@ -25,13 +25,13 @@ if ( ! empty($_FILES)) {
         echo json_encode([
             'status' => 'uploading',
             'bytes_uploaded' => $bytesUploaded,
-            'checksum' => $client->getChecksum(),
+            'upload_key' => $uploadKey
         ]);
     } catch (ConnectionException | FileException | TusException $e) {
         echo json_encode([
             'status' => 'error',
             'bytes_uploaded' => -1,
-            'checksum' => '',
+            'upload_key' => '',
             'error' => $e->getMessage(),
         ]);
     }

--- a/example/basic/verify.php
+++ b/example/basic/verify.php
@@ -8,7 +8,6 @@
 require __DIR__ . '/../../vendor/autoload.php';
 
 use TusPhp\Exception\FileException;
-use TusPhp\Exception\ConnectionException;
 use GuzzleHttp\Exception\ConnectException;
 
 $client = new \TusPhp\Tus\Client('http://tus-php-server');
@@ -31,9 +30,9 @@ if ( ! empty($_FILES)) {
         echo json_encode([
             'status' => $status,
             'bytes_uploaded' => $offset,
-            'checksum' => $client->getChecksum(),
+            'upload_key' => $uploadKey,
         ]);
-    } catch (ConnectionException | ConnectException $e) {
+    } catch (ConnectException $e) {
         echo json_encode([
             'status' => 'error',
             'bytes_uploaded' => -1,
@@ -42,7 +41,7 @@ if ( ! empty($_FILES)) {
         echo json_encode([
             'status' => 'resume',
             'bytes_uploaded' => 0,
-            'checksum' => '',
+            'upload_key' => '',
         ]);
     }
 } else {


### PR DESCRIPTION
After the file is uploaded on the basic example upload page. It shows the
download link on the same page. Once that download link is clicked then
it should download the uploaded file. That download link was broken.
This change fixes the same broken download link.

