### PR TITLE
Treat HEAD and GET as an identical request

### DIFF
--- a/example/basic/index.php
+++ b/example/basic/index.php
@@ -328,7 +328,7 @@
     completedUploads.find('p.info').remove();
     completedUploads.append(
       '<div class="panel panel-default"><div class="panel-body"><a href="<?= (string) (getenv('SERVER_URL') ?? '') ?>/files/'
-      + uploadKey + '">' + fileMeta.name + '</a> (' + fileMeta.size + ' bytes)</div></div>'
+      + uploadKey + '/get">' + fileMeta.name + '</a> (' + fileMeta.size + ' bytes)</div></div>'
     );
   };
 

--- a/src/Tus/Server.php
+++ b/src/Tus/Server.php
@@ -492,11 +492,31 @@ class Server extends AbstractTus
     /**
      * Handle GET request.
      *
+     * As per RFC7231, we need to treat HEAD and GET as an identical request.
+     * All major PHP frameworks follows the same and silently transforms each
+     * HEAD requests to GET.
+     *
      * @return BinaryFileResponse|HttpResponse
      */
     protected function handleGet()
     {
-        $key = $this->request->key();
+        // We will treat '/files/<key>/get' as a download request.
+        if ('get' === $this->request->key()) {
+            return $this->handleDownload();
+        }
+
+        return $this->handleHead();
+    }
+
+    /**
+     * Handle Download request.
+     *
+     * @return BinaryFileResponse|HttpResponse
+     */
+    protected function handleDownload()
+    {
+        $path = explode('/', str_replace('/get', '', $this->request->path()));
+        $key  = end($path);
 
         if ($this->request->path() === $this->getApiPath()) {
             return $this->response->send('400 bad request.', HttpResponse::HTTP_BAD_REQUEST);

--- a/tests/Tus/ServerTest.php
+++ b/tests/Tus/ServerTest.php
@@ -1694,6 +1694,81 @@ class ServerTest extends TestCase
      *
      * @covers ::handleGet
      */
+    public function it_treats_head_and_get_as_identical_request()
+    {
+        $key = '74f02d6da32082463e382';
+
+        $this->tusServerMock
+            ->getRequest()
+            ->getRequest()
+            ->server
+            ->add([
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/tus/files/' . $key,
+            ]);
+
+        $this->tusServerMock->setApiPath('/tus/files');
+
+        $responseMock = m::mock(HttpResponse::class);
+
+        $responseMock
+            ->shouldReceive('getStatusCode')
+            ->once()
+            ->andReturn(200);
+
+        $this->tusServerMock
+            ->shouldReceive('handleHead')
+            ->once()
+            ->andReturn($responseMock);
+
+        $response = $this->tusServerMock->handleGet();
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::handleGet
+     */
+    public function it_sends_a_download_request_when_calling_get()
+    {
+        $key = '74f02d6da32082463e382';
+
+        $this->tusServerMock
+            ->getRequest()
+            ->getRequest()
+            ->server
+            ->add([
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/tus/files/' . $key . '/get',
+            ]);
+
+        $this->tusServerMock->setApiPath('/tus/files');
+
+        $responseMock = m::mock(HttpResponse::class);
+
+        $responseMock
+            ->shouldReceive('getStatusCode')
+            ->once()
+            ->andReturn(200);
+
+        $this->tusServerMock
+            ->shouldReceive('handleDownload')
+            ->once()
+            ->andReturn($responseMock);
+
+        $response = $this->tusServerMock->handleGet();
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::handleGet
+     * @covers ::handleDownload
+     */
     public function it_returns_400_for_request_without_hash()
     {
         $this->tusServerMock
@@ -1707,7 +1782,7 @@ class ServerTest extends TestCase
 
         $this->tusServerMock->setApiPath('/tus/files');
 
-        $response = $this->tusServerMock->handleGet();
+        $response = $this->tusServerMock->handleDownload();
 
         $this->assertEquals(400, $response->getStatusCode());
         $this->assertEquals('400 bad request.', $response->getContent());
@@ -1717,8 +1792,9 @@ class ServerTest extends TestCase
      * @test
      *
      * @covers ::handleGet
+     * @covers ::handleDownload
      */
-    public function it_returns_404_for_invalid_get_request()
+    public function it_returns_404_for_invalid_download_request()
     {
         $checksum = '74f02d6da32082463e382f2274e85fd8eae3e81f739f8959abc91865656e3b3a';
 
@@ -1728,7 +1804,7 @@ class ServerTest extends TestCase
             ->server
             ->add([
                 'REQUEST_METHOD' => 'GET',
-                'REQUEST_URI' => '/files/' . $checksum,
+                'REQUEST_URI' => '/files/' . $checksum . '/get',
             ]);
 
         $cacheMock = m::mock(FileStore::class);
@@ -1750,6 +1826,7 @@ class ServerTest extends TestCase
      * @test
      *
      * @covers ::handleGet
+     * @covers ::handleDownload
      */
     public function it_returns_404_if_resource_doesnt_exist()
     {
@@ -1761,7 +1838,7 @@ class ServerTest extends TestCase
             ->server
             ->add([
                 'REQUEST_METHOD' => 'GET',
-                'REQUEST_URI' => '/files/' . $checksum,
+                'REQUEST_URI' => '/files/' . $checksum . '/get',
             ]);
 
         $cacheMock = m::mock(FileStore::class);
@@ -1785,8 +1862,9 @@ class ServerTest extends TestCase
      * @test
      *
      * @covers ::handleGet
+     * @covers ::handleDownload
      */
-    public function it_handles_get_request()
+    public function it_handles_download_request()
     {
         $fileName  = 'file.txt';
         $fileSize  = 1024;
@@ -1809,7 +1887,7 @@ class ServerTest extends TestCase
             ->server
             ->add([
                 'REQUEST_METHOD' => 'GET',
-                'REQUEST_URI' => '/files/' . $checksum,
+                'REQUEST_URI' => '/files/' . $checksum . '/get',
             ]);
 
         $cacheMock = m::mock(FileStore::class);


### PR DESCRIPTION
Related: #86, symfony/symfony#28743

[RFC7231](https://tools.ietf.org/html/rfc7231#section-4.3.2) states that the `HEAD` method is identical to `GET` and all major PHP frameworks silently transforms `HEAD` requests to `GET`. This causes issue when using tus-php with PHP frameworks as it treats `GET` request as a file download request. 

File download in `GET /files/<key>` request is not a part of the tus specification. So to align with others, unlike [official tus server implementation](https://github.com/tus/tusd/blob/master/unrouted_handler.go#L583), this PR moves download request to `GET /files/<key>/get` endpoint and treats `HEAD` and `GET` as an identical request.