### PR TITLE
[Issue fix/#96] Add missing checks in patch request #96

### DIFF
--- a/src/Tus/AbstractTus.php
+++ b/src/Tus/AbstractTus.php
@@ -22,14 +22,14 @@ abstract class AbstractTus
     /** @const string Upload type final. */
     const UPLOAD_TYPE_FINAL = 'final';
 
+    /** @const string Header Content Type */
+    const HEADER_CONTENT_TYPE = 'application/offset+octet-stream';
+
     /** @var Cacheable */
     protected $cache;
 
     /** @var string */
     protected $apiPath = '/files';
-
-    /** @const string Content Type */
-    const HEADER_CONTENT_TYPE = 'application/offset+octet-stream';
 
     /**
      * Set cache.

--- a/src/Tus/AbstractTus.php
+++ b/src/Tus/AbstractTus.php
@@ -28,6 +28,9 @@ abstract class AbstractTus
     /** @var string */
     protected $apiPath = '/files';
 
+    /** @const string Content Type */
+    const HEADER_CONTENT_TYPE = 'application/offset+octet-stream';
+
     /**
      * Set cache.
      *

--- a/src/Tus/Client.php
+++ b/src/Tus/Client.php
@@ -450,6 +450,14 @@ class Client extends AbstractTus
                 throw new ConnectionException('Connection aborted by user.');
             }
 
+            if (HttpResponse::HTTP_UNSUPPORTED_MEDIA_TYPE == $statusCode) {
+                throw new ConnectionException('Unsupported media Types.');
+            }
+
+            if (HttpResponse::HTTP_BAD_REQUEST === $statusCode) {
+                throw new ConnectionException('Bad request.');
+            }
+
             throw new Exception($e->getResponse()->getBody(), $statusCode);
         } catch (ConnectException $e) {
             throw new ConnectionException("Couldn't connect to server.");

--- a/src/Tus/Client.php
+++ b/src/Tus/Client.php
@@ -425,7 +425,7 @@ class Client extends AbstractTus
     {
         $data    = $this->getData($offset, $bytes);
         $headers = [
-            'Content-Type' => 'application/offset+octet-stream',
+            'Content-Type' => self::HEADER_CONTENT_TYPE,
             'Content-Length' => strlen($data),
             'Upload-Checksum' => $this->getUploadChecksumHeader(),
         ];
@@ -453,11 +453,7 @@ class Client extends AbstractTus
             }
 
             if (HttpResponse::HTTP_UNSUPPORTED_MEDIA_TYPE === $statusCode) {
-                throw new ConnectionException('Unsupported media Types.');
-            }
-
-            if (HttpResponse::HTTP_BAD_REQUEST === $statusCode) {
-                throw new ConnectionException('Bad request.');
+                throw new Exception('Unsupported media Types.');
             }
 
             throw new Exception($e->getResponse()->getBody(), $statusCode);

--- a/src/Tus/Client.php
+++ b/src/Tus/Client.php
@@ -452,7 +452,7 @@ class Client extends AbstractTus
                 throw new ConnectionException('Connection aborted by user.');
             }
 
-            if (HttpResponse::HTTP_UNSUPPORTED_MEDIA_TYPE == $statusCode) {
+            if (HttpResponse::HTTP_UNSUPPORTED_MEDIA_TYPE === $statusCode) {
                 throw new ConnectionException('Unsupported media Types.');
             }
 

--- a/src/Tus/Server.php
+++ b/src/Tus/Server.php
@@ -32,6 +32,9 @@ class Server extends AbstractTus
     /** @const string Tus Concatenation Extension */
     const TUS_EXTENSION_CONCATENATION = 'concatenation';
 
+    /** @const string Tus Content Type Extension  */
+    const TUS_EXTENSION_CONTENT_TYPE = 'application/offset+octet-stream';
+
     /** @const array All supported tus extensions */
     const TUS_EXTENSIONS = [
         self::TUS_EXTENSION_CREATION,
@@ -39,6 +42,7 @@ class Server extends AbstractTus
         self::TUS_EXTENSION_CHECKSUM,
         self::TUS_EXTENSION_EXPIRATION,
         self::TUS_EXTENSION_CONCATENATION,
+        self::TUS_EXTENSION_CONTENT_TYPE,
     ];
 
     /** @const int 460 Checksum Mismatch */
@@ -484,6 +488,17 @@ class Server extends AbstractTus
 
         if ($uploadOffset && $uploadOffset !== (string) $meta['offset']) {
             return HttpResponse::HTTP_CONFLICT;
+        }
+
+        $contentType   = $this->request->header('Content-Type');
+        $contentLength = $this->request->header('Content-Length');
+
+        if (!$contentType || $contentType !== self::TUS_EXTENSION_CONTENT_TYPE ) {
+            return HTTPRESPONSE::HTTP_UNSUPPORTED_MEDIA_TYPE;
+        }
+
+        if (!$contentLength || $contentLength <= 0) {
+            return HttpResponse::HTTP_BAD_REQUEST;
         }
 
         return HttpResponse::HTTP_OK;

--- a/src/Tus/Server.php
+++ b/src/Tus/Server.php
@@ -33,7 +33,7 @@ class Server extends AbstractTus
     const TUS_EXTENSION_CONCATENATION = 'concatenation';
 
     /** @const string Tus Content Type Extension  */
-    const TUS_EXTENSION_CONTENT_TYPE = 'application/offset+octet-stream';
+    const HEADER_CONTENT_TYPE = 'application/offset+octet-stream';
 
     /** @const array All supported tus extensions */
     const TUS_EXTENSIONS = [
@@ -42,7 +42,6 @@ class Server extends AbstractTus
         self::TUS_EXTENSION_CHECKSUM,
         self::TUS_EXTENSION_EXPIRATION,
         self::TUS_EXTENSION_CONCATENATION,
-        self::TUS_EXTENSION_CONTENT_TYPE,
     ];
 
     /** @const int 460 Checksum Mismatch */
@@ -493,7 +492,7 @@ class Server extends AbstractTus
         $contentType   = $this->request->header('Content-Type');
         $contentLength = $this->request->header('Content-Length');
 
-        if ( ! $contentType || $contentType !== self::TUS_EXTENSION_CONTENT_TYPE) {
+        if ( ! $contentType || $contentType !== self::HEADER_CONTENT_TYPE) {
             return HTTPRESPONSE::HTTP_UNSUPPORTED_MEDIA_TYPE;
         }
 

--- a/src/Tus/Server.php
+++ b/src/Tus/Server.php
@@ -32,9 +32,6 @@ class Server extends AbstractTus
     /** @const string Tus Concatenation Extension */
     const TUS_EXTENSION_CONCATENATION = 'concatenation';
 
-    /** @const string Tus Content Type Extension  */
-    const HEADER_CONTENT_TYPE = 'application/offset+octet-stream';
-
     /** @const array All supported tus extensions */
     const TUS_EXTENSIONS = [
         self::TUS_EXTENSION_CREATION,
@@ -464,7 +461,7 @@ class Server extends AbstractTus
         }
 
         return $this->response->send(null, HttpResponse::HTTP_NO_CONTENT, [
-            'Content-Type' => 'application/offset+octet-stream',
+            'Content-Type' => self::HEADER_CONTENT_TYPE,
             'Upload-Expires' => $this->cache->get($uploadKey)['expires_at'],
             'Upload-Offset' => $offset,
         ]);
@@ -490,14 +487,9 @@ class Server extends AbstractTus
         }
 
         $contentType   = $this->request->header('Content-Type');
-        $contentLength = $this->request->header('Content-Length');
 
-        if ( ! $contentType || $contentType !== self::HEADER_CONTENT_TYPE) {
+        if ($contentType !== self::HEADER_CONTENT_TYPE) {
             return HTTPRESPONSE::HTTP_UNSUPPORTED_MEDIA_TYPE;
-        }
-
-        if ( ! $contentLength || $contentLength <= 0) {
-            return HttpResponse::HTTP_BAD_REQUEST;
         }
 
         return HttpResponse::HTTP_OK;

--- a/src/Tus/Server.php
+++ b/src/Tus/Server.php
@@ -493,11 +493,11 @@ class Server extends AbstractTus
         $contentType   = $this->request->header('Content-Type');
         $contentLength = $this->request->header('Content-Length');
 
-        if (!$contentType || $contentType !== self::TUS_EXTENSION_CONTENT_TYPE ) {
+        if ( ! $contentType || $contentType !== self::TUS_EXTENSION_CONTENT_TYPE) {
             return HTTPRESPONSE::HTTP_UNSUPPORTED_MEDIA_TYPE;
         }
 
-        if (!$contentLength || $contentLength <= 0) {
+        if ( ! $contentLength || $contentLength <= 0) {
             return HttpResponse::HTTP_BAD_REQUEST;
         }
 

--- a/src/Tus/Server.php
+++ b/src/Tus/Server.php
@@ -494,7 +494,7 @@ class Server extends AbstractTus
             return HttpResponse::HTTP_CONFLICT;
         }
 
-        $contentType   = $this->request->header('Content-Type');
+        $contentType = $this->request->header('Content-Type');
 
         if ($contentType !== self::HEADER_CONTENT_TYPE) {
             return HTTPRESPONSE::HTTP_UNSUPPORTED_MEDIA_TYPE;

--- a/tests/Tus/ServerTest.php
+++ b/tests/Tus/ServerTest.php
@@ -1475,12 +1475,6 @@ class ServerTest extends TestCase
             ->set('Content-Type', 'application/offset+octet-stream');
 
         $this->tusServerMock
-            ->getRequest()
-            ->getRequest()
-            ->headers
-            ->set('Content-Length', 200);
-
-        $this->tusServerMock
             ->shouldReceive('buildFile')
             ->once()
             ->with($fileMeta)
@@ -1584,12 +1578,6 @@ class ServerTest extends TestCase
         $this->tusServerMock
             ->getRequest()
             ->getRequest()
-            ->headers
-            ->set('Content-Length', 200);
-
-        $this->tusServerMock
-            ->getRequest()
-            ->getRequest()
             ->server
             ->add([
                 'REQUEST_METHOD' => 'PATCH',
@@ -1672,12 +1660,6 @@ class ServerTest extends TestCase
             ->getRequest()
             ->headers
             ->set('Content-Type', 'application/offset+octet-stream');
-
-        $this->tusServerMock
-            ->getRequest()
-            ->getRequest()
-            ->headers
-            ->set('Content-Length', 200);
 
         $this->tusServerMock
             ->getRequest()
@@ -2642,12 +2624,6 @@ class ServerTest extends TestCase
                 'REQUEST_METHOD' => 'PATCH',
                 'REQUEST_URI' => '/files/' . $key,
             ]);
-
-        $this->tusServerMock
-            ->getRequest()
-            ->getRequest()
-            ->headers
-            ->set('Content-Length', 100);
 
         $cacheMock = m::mock(FileStore::class);
         $cacheMock

--- a/tests/Tus/ServerTest.php
+++ b/tests/Tus/ServerTest.php
@@ -1272,12 +1272,6 @@ class ServerTest extends TestCase
         $this->tusServerMock
             ->getRequest()
             ->getRequest()
-            ->headers
-            ->set('Content-Length', 200);
-
-        $this->tusServerMock
-            ->getRequest()
-            ->getRequest()
             ->server
             ->add([
                 'REQUEST_METHOD' => 'PATCH',
@@ -1360,12 +1354,6 @@ class ServerTest extends TestCase
             ->getRequest()
             ->headers
             ->set('Content-Type', 'application/offset+octet-stream');
-
-        $this->tusServerMock
-            ->getRequest()
-            ->getRequest()
-            ->headers
-            ->set('Content-Length', 200);
 
         $this->tusServerMock
             ->getRequest()
@@ -2673,62 +2661,6 @@ class ServerTest extends TestCase
         $response = $this->tusServerMock->handlePatch();
 
         $this->assertEquals(415, $response->getStatusCode());
-        $this->assertEmpty($response->getContent());
-    }
-
-    /**
-     * @test
-     *
-     * @covers ::handlePatch
-     * @covers ::verifyPatchRequest
-     */
-    public function it_returns_400_for_content_length_mismatch()
-    {
-        $key       = uniqid();
-        $fileName  = 'file.txt';
-        $fileSize  = 1024;
-        $checksum  = '74f02d6da32082463e382f2274e85fd8eae3e81f739f8959abc91865656e3b3a';
-        $location  = 'http://tus.local/uploads/file.txt';
-        $expiresAt = 'Sat, 09 Dec 2017 00:00:00 GMT';
-        $fileMeta  = [
-            'name' => $fileName,
-            'size' => $fileSize,
-            'offset' => 0,
-            'checksum' => $checksum,
-            'file_path' => dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName,
-            'location' => $location,
-            'created_at' => 'Fri, 08 Dec 2017 00:00:00 GMT',
-            'expires_at' => $expiresAt,
-            'upload_type' => 'normal',
-        ];
-
-        $this->tusServerMock
-            ->getRequest()
-            ->getRequest()
-            ->server
-            ->add([
-                'REQUEST_METHOD' => 'PATCH',
-                'REQUEST_URI' => '/files/' . $key,
-            ]);
-
-        $this->tusServerMock
-            ->getRequest()
-            ->getRequest()
-            ->headers
-            ->set('Content-Type', 'application/offset+octet-stream');
-
-        $cacheMock = m::mock(FileStore::class);
-        $cacheMock
-            ->shouldReceive('get')
-            ->once()
-            ->with($key)
-            ->andReturn($fileMeta);
-
-        $this->tusServerMock->setCache($cacheMock);
-
-        $response = $this->tusServerMock->handlePatch();
-
-        $this->assertEquals(400, $response->getStatusCode());
         $this->assertEmpty($response->getContent());
     }
 

--- a/tests/Tus/ServerTest.php
+++ b/tests/Tus/ServerTest.php
@@ -1263,7 +1263,7 @@ class ServerTest extends TestCase
             'upload_type' => 'normal',
         ];
 
-      $this->tusServerMock
+        $this->tusServerMock
           ->getRequest()
           ->getRequest()
           ->headers

--- a/tests/Tus/ServerTest.php
+++ b/tests/Tus/ServerTest.php
@@ -2706,7 +2706,7 @@ class ServerTest extends TestCase
             'size' => $fileSize,
             'offset' => 0,
             'checksum' => $checksum,
-            'file_path' => dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName,
+            'file_path' => dirname(__DIR__) . DIRECTORY_SEPARATOR . $fileName,
             'location' => $location,
             'created_at' => 'Fri, 08 Dec 2017 00:00:00 GMT',
             'expires_at' => $expiresAt,


### PR DESCRIPTION
- [x] All PATCH requests MUST use Content-Type: application/offset+octet-stream, otherwise the server SHOULD return a 415 Unsupported Media Type status.

- [x] ~~If a PATCH request does not include a Content-Length header containing an integer value larger than 0, the server SHOULD return a 400 Bad Request status.~~

- [x] Test Coverage