### PR TITLE
Fix issue when no Origin header is set.

### DIFF
--- a/src/Middleware/Cors.php
+++ b/src/Middleware/Cors.php
@@ -16,7 +16,7 @@ class Cors implements TusMiddleware
     public function handle(Request $request, Response $response)
     {
         $response->setHeaders([
-            'Access-Control-Allow-Origin' => $request->header('Origin') ?? "*",
+            'Access-Control-Allow-Origin' => $request->header('Origin') ?? '*',
             'Access-Control-Allow-Methods' => implode(',', $request->allowedHttpVerbs()),
             'Access-Control-Allow-Headers' => 'Origin, X-Requested-With, Content-Type, Content-Length, Upload-Key, Upload-Checksum, Upload-Length, Upload-Offset, Tus-Version, Tus-Resumable, Upload-Metadata',
             'Access-Control-Expose-Headers' => 'Upload-Key, Upload-Checksum, Upload-Length, Upload-Offset, Upload-Metadata, Tus-Version, Tus-Resumable, Tus-Extension, Location',

--- a/src/Middleware/Cors.php
+++ b/src/Middleware/Cors.php
@@ -16,7 +16,7 @@ class Cors implements TusMiddleware
     public function handle(Request $request, Response $response)
     {
         $response->setHeaders([
-            'Access-Control-Allow-Origin' => $request->header('Origin'),
+            'Access-Control-Allow-Origin' => $request->header('Origin') ?? "*",
             'Access-Control-Allow-Methods' => implode(',', $request->allowedHttpVerbs()),
             'Access-Control-Allow-Headers' => 'Origin, X-Requested-With, Content-Type, Content-Length, Upload-Key, Upload-Checksum, Upload-Length, Upload-Offset, Tus-Version, Tus-Resumable, Upload-Metadata',
             'Access-Control-Expose-Headers' => 'Upload-Key, Upload-Checksum, Upload-Length, Upload-Offset, Upload-Metadata, Tus-Version, Tus-Resumable, Tus-Extension, Location',


### PR DESCRIPTION
**Describe the bug**

At the middleware `TusPhp\Middleware\Cor` its possible for the header `Access-Control-Allow-Origin` to be set as `null`. This can cause issues down the line, specially if you're trying to convert the TUS response into a PSR7 object using `Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory`.

Here is the affected chunk:

```
 public function handle(Request $request, Response $response)
    {
        $response->setHeaders([
            'Access-Control-Allow-Origin' => $request->header('Origin'),
            'Access-Control-Allow-Methods' => implode(',', $request->allowedHttpVerbs()),
```
If `$request->header('Origin')` returns `null` and we use the response with `DiactorosFactory` we get:
```
Zend\Diactoros\Exception\InvalidArgumentException: Invalid header value type; must be a string or numeric; received NULL in ...vendor\zendframework\zend-diactoros\src\HeaderSecurity.php:139`
```

Fixes #114 