### PR TITLE
Allow serving requests without relying on global request scope

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -13,11 +13,13 @@ class Request
     /**
      * Request constructor.
      */
-    public function __construct()
+    public function __construct(HttpRequest $request = null)
     {
-        if (null === $this->request) {
-            $this->request = HttpRequest::createFromGlobals();
+        if (null === $request) {
+            $request = HttpRequest::createFromGlobals();
         }
+
+        $this->request = $request;
     }
 
     /**

--- a/src/Tus/Server.php
+++ b/src/Tus/Server.php
@@ -252,8 +252,12 @@ class Server extends AbstractTus
      *
      * @return HttpResponse|BinaryFileResponse
      */
-    public function serve()
+    public function serve(Request $request = null)
     {
+        if ($request !== null) {
+            $this->request = $request;
+        }
+
         $this->applyMiddleware();
 
         $requestMethod = $this->getRequest()->method();

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -247,4 +247,18 @@ class RequestTest extends TestCase
     {
         $this->assertInstanceOf(HttpRequest::class, $this->request->getRequest());
     }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     */
+    public function it_allows_construction_without_global_request_scope()
+    {
+        $httpFoundationRequest = new HttpRequest();
+        $httpFoundationRequest->setMethod('POST');
+
+        $this->request = new Request($httpFoundationRequest);
+        $this->assertSame('POST', $this->request->method());
+    }
 }

--- a/tests/Tus/ServerTest.php
+++ b/tests/Tus/ServerTest.php
@@ -2,6 +2,7 @@
 
 namespace TusPhp\Test;
 
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use TusPhp\File;
 use Mockery as m;
 use TusPhp\Request;
@@ -183,6 +184,21 @@ class ServerTest extends TestCase
      *
      * @covers ::serve
      */
+    public function it_allows_serving_a_specific_request()
+    {
+        $httpFoundationRequest = new HttpRequest();
+        $httpFoundationRequest->setMethod('INVALID');
+
+        $response = $this->tusServerMock->serve(new Request($httpFoundationRequest));
+
+        $this->assertEquals(405, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::serve
+     */
     public function it_sends_405_for_invalid_http_verbs()
     {
         $this->tusServerMock
@@ -227,7 +243,7 @@ class ServerTest extends TestCase
             ->server
             ->set('REQUEST_METHOD', 'HEAD');
 
-        $requestMock = m::mock(Request::class, ['file'])->makePartial();
+        $requestMock = m::mock(Request::class, [])->makePartial();
         $requestMock
             ->getRequest()
             ->headers
@@ -275,7 +291,7 @@ class ServerTest extends TestCase
             ->server
             ->set('REQUEST_METHOD', 'HEAD');
 
-        $requestMock = m::mock(Request::class, ['file'])->makePartial();
+        $requestMock = m::mock(Request::class, [])->makePartial();
         $requestMock
             ->getRequest()
             ->headers
@@ -353,7 +369,7 @@ class ServerTest extends TestCase
 
         $tusServerMock->__construct('file');
 
-        $requestMock = m::mock(Request::class, ['file'])->makePartial();
+        $requestMock = m::mock(Request::class, [])->makePartial();
         $requestMock
             ->getRequest()
             ->headers
@@ -754,7 +770,7 @@ class ServerTest extends TestCase
                 'REQUEST_URI' => '/files',
             ]);
 
-        $requestMock = m::mock(Request::class, ['file'])->makePartial();
+        $requestMock = m::mock(Request::class, [])->makePartial();
         $requestMock
             ->getRequest()
             ->headers
@@ -804,7 +820,7 @@ class ServerTest extends TestCase
                 'REQUEST_URI' => '/files',
             ]);
 
-        $requestMock = m::mock(Request::class, ['file'])->makePartial();
+        $requestMock = m::mock(Request::class, [])->makePartial();
         $requestMock
             ->getRequest()
             ->headers
@@ -866,7 +882,7 @@ class ServerTest extends TestCase
                 'REQUEST_URI' => '/files',
             ]);
 
-        $requestMock = m::mock(Request::class, ['file'])->makePartial();
+        $requestMock = m::mock(Request::class, [])->makePartial();
         $requestMock
             ->getRequest()
             ->headers
@@ -986,7 +1002,7 @@ class ServerTest extends TestCase
                 'REQUEST_URI' => '/files',
             ]);
 
-        $requestMock = m::mock(Request::class, ['file'])->makePartial();
+        $requestMock = m::mock(Request::class, [])->makePartial();
         $requestMock
             ->getRequest()
             ->headers
@@ -1105,7 +1121,7 @@ class ServerTest extends TestCase
             'location' => $location,
         ];
 
-        $requestMock = m::mock(Request::class, ['file'])->makePartial();
+        $requestMock = m::mock(Request::class, [])->makePartial();
         $requestMock
             ->getRequest()
             ->headers
@@ -1261,7 +1277,7 @@ class ServerTest extends TestCase
             ['file_path' => $filePath . 'file_b', 'offset' => 20],
         ];
 
-        $requestMock = m::mock(Request::class, ['file'])->makePartial();
+        $requestMock = m::mock(Request::class, [])->makePartial();
         $requestMock
             ->getRequest()
             ->headers
@@ -2995,7 +3011,7 @@ class ServerTest extends TestCase
     {
         $this->assertTrue($this->tusServerMock->verifyUploadSize());
 
-        $requestMock = m::mock(Request::class, ['file'])->makePartial();
+        $requestMock = m::mock(Request::class, [])->makePartial();
         $requestMock
             ->getRequest()
             ->headers


### PR DESCRIPTION
I'm trying to integrate this library into our application, and in the process of writing some functional tests. 

Since in https://github.com/ankitpokhrel/tus-php/blob/master/src/Request.php#L19 when the `Request` is instantiated the underlying http foundation request is unset, it always relies on the global request scope using `createFromGlobals`. 

I need this library to serve the request that the Symfony Kernel provides rather than trying to build a second request object. 

This PR allows my controller to look as follows, and for me to be able to test the whole process:

```    /**
     * TUS upload endpoint
     *
     * @Route("/documents/uploads/tus/", name="tus_post")
     * @Route("/documents/uploads/tus/{token?}", name="tus", requirements={"token"=".+"})
     *
     */
    public function server(Request $request, Server $server)
    {
        return $server->serve(new \TusPhp\Request($request));
    }
```