### PR TITLE
Set additional metadata in Upload-Metadata header

### DIFF
--- a/src/Tus/Client.php
+++ b/src/Tus/Client.php
@@ -45,6 +45,9 @@ class Client extends AbstractTus
     /** @var string */
     protected $checksumAlgorithm = 'sha256';
 
+    /** @var array */
+    protected $metadata = [];
+
     /**
      * Client constructor.
      *
@@ -170,6 +173,79 @@ class Client extends AbstractTus
         }
 
         return $this->checksum;
+    }
+
+    /**
+     * Add metadata.
+     *
+     * @param string $key
+     * @param string $value
+     *
+     * @return Client
+     */
+    public function addMetadata(string $key, string $value) : self
+    {
+        $this->metadata[$key] = base64_encode($value);
+
+        return $this;
+    }
+
+    /**
+     * Remove metadata.
+     *
+     * @param string $key
+     *
+     * @return Client
+     */
+    public function removeMetadata(string $key) : self
+    {
+        unset($this->metadata[$key]);
+
+        return $this;
+    }
+
+    /**
+     * Set metadata.
+     *
+     * @param array $items
+     *
+     * @return Client
+     */
+    public function setMetadata(array $items) : self
+    {
+        $items = array_map('base64_encode', $items);
+
+        $this->metadata = $items;
+
+        return $this;
+    }
+
+    /**
+     * Get metadata.
+     *
+     * @return array
+     */
+    public function getMetadata() : array
+    {
+        $this->addMetadata('filename ', $this->fileName);
+
+        return $this->metadata;
+    }
+
+    /**
+     * Get metadata for Upload-Metadata header.
+     *
+     * @return string
+     */
+    protected function getUploadMetadata() : string
+    {
+        $metadata = [];
+
+        foreach ($this->getMetadata() as $key => $value) {
+            $metadata[] = "{$key} {$value}";
+        }
+
+        return implode(',', $metadata);
     }
 
     /**
@@ -349,7 +425,7 @@ class Client extends AbstractTus
             'Upload-Length' => $this->fileSize,
             'Upload-Key' => $key,
             'Upload-Checksum' => $this->getUploadChecksumHeader(),
-            'Upload-Metadata' => 'filename ' . base64_encode($this->fileName),
+            'Upload-Metadata' => $this->getUploadMetadata(),
         ];
 
         if ($this->isPartial()) {
@@ -391,7 +467,7 @@ class Client extends AbstractTus
                 'Upload-Length' => $this->fileSize,
                 'Upload-Key' => $key,
                 'Upload-Checksum' => $this->getUploadChecksumHeader(),
-                'Upload-Metadata' => 'filename ' . base64_encode($this->fileName),
+                'Upload-Metadata' => $this->getUploadMetadata(),
                 'Upload-Concat' => self::UPLOAD_TYPE_FINAL . ';' . implode(' ', $partials),
             ],
         ]);


### PR DESCRIPTION
According to https://tus.io/protocols/resumable-upload.html#upload-metadata the Upload-Metadata header could contain multiple items.