### PR TITLE
Set additional metadata in Upload-Metadata header

### DIFF
--- a/src/Tus/Client.php
+++ b/src/Tus/Client.php
@@ -45,6 +45,9 @@ class Client extends AbstractTus
     /** @var string */
     protected $checksumAlgorithm = 'sha256';
 
+    /** @var array */
+    protected $metadata = [];
+
     /**
      * Client constructor.
      *
@@ -86,6 +89,8 @@ class Client extends AbstractTus
 
         $this->fileName = $name ?? basename($this->filePath);
         $this->fileSize = filesize($file);
+
+        $this->addMetadata('filename', $this->fileName);
 
         return $this;
     }
@@ -170,6 +175,77 @@ class Client extends AbstractTus
         }
 
         return $this->checksum;
+    }
+
+    /**
+     * Add metadata.
+     *
+     * @param string $key
+     * @param string $value
+     *
+     * @return Client
+     */
+    public function addMetadata(string $key, string $value) : self
+    {
+        $this->metadata[$key] = base64_encode($value);
+
+        return $this;
+    }
+
+    /**
+     * Remove metadata.
+     *
+     * @param string $key
+     *
+     * @return Client
+     */
+    public function removeMetadata(string $key) : self
+    {
+        unset($this->metadata[$key]);
+
+        return $this;
+    }
+
+    /**
+     * Set metadata.
+     *
+     * @param array $items
+     *
+     * @return Client
+     */
+    public function setMetadata(array $items) : self
+    {
+        $items = array_map('base64_encode', $items);
+
+        $this->metadata = $items;
+
+        return $this;
+    }
+
+    /**
+     * Get metadata.
+     *
+     * @return array
+     */
+    public function getMetadata() : array
+    {
+        return $this->metadata;
+    }
+
+    /**
+     * Get metadata for Upload-Metadata header.
+     *
+     * @return string
+     */
+    protected function getUploadMetadataHeader() : string
+    {
+        $metadata = [];
+
+        foreach ($this->getMetadata() as $key => $value) {
+            $metadata[] = "{$key} {$value}";
+        }
+
+        return implode(',', $metadata);
     }
 
     /**
@@ -349,7 +425,7 @@ class Client extends AbstractTus
             'Upload-Length' => $this->fileSize,
             'Upload-Key' => $key,
             'Upload-Checksum' => $this->getUploadChecksumHeader(),
-            'Upload-Metadata' => 'filename ' . base64_encode($this->fileName),
+            'Upload-Metadata' => $this->getUploadMetadataHeader(),
         ];
 
         if ($this->isPartial()) {
@@ -391,7 +467,7 @@ class Client extends AbstractTus
                 'Upload-Length' => $this->fileSize,
                 'Upload-Key' => $key,
                 'Upload-Checksum' => $this->getUploadChecksumHeader(),
-                'Upload-Metadata' => 'filename ' . base64_encode($this->fileName),
+                'Upload-Metadata' => $this->getUploadMetadataHeader(),
                 'Upload-Concat' => self::UPLOAD_TYPE_FINAL . ';' . implode(' ', $partials),
             ],
         ]);

--- a/tests/Tus/ClientTest.php
+++ b/tests/Tus/ClientTest.php
@@ -120,6 +120,49 @@ class ClientTest extends TestCase
     /**
      * @test
      *
+     * @covers ::addMetadata
+     * @covers ::removeMetadata
+     * @covers ::setMetadata
+     * @covers ::getMetadata
+     */
+    public function it_sets_and_gets_metadata()
+    {
+        $filePath = __DIR__ . '/../Fixtures/empty.txt';
+
+        $this->tusClient->file($filePath);
+        $this->assertEquals([
+            'filename' => base64_encode('empty.txt')
+        ], $this->tusClient->getMetadata());
+
+        $this->tusClient->addMetadata('filename', 'file.mp4');
+        $this->assertEquals([
+            'filename' => base64_encode('file.mp4')
+        ], $this->tusClient->getMetadata());
+
+        $this->tusClient->addMetadata('filetype', 'video/mp4');
+        $this->assertEquals([
+            'filename' => base64_encode('file.mp4'),
+            'filetype' => base64_encode('video/mp4')
+        ], $this->tusClient->getMetadata());
+
+        $this->tusClient->setMetadata([
+            'filename' => 'file.mp4',
+            'filetype' => 'video/mp4'
+        ]);
+        $this->assertEquals([
+            'filename' => base64_encode('file.mp4'),
+            'filetype' => base64_encode('video/mp4')
+        ], $this->tusClient->getMetadata());
+
+        $this->tusClient->removeMetadata('filetype');
+        $this->assertEquals([
+            'filename' => base64_encode('file.mp4'),
+        ], $this->tusClient->getMetadata());
+    }
+
+    /**
+     * @test
+     *
      * @covers ::__construct
      * @covers ::getClient
      */
@@ -1737,6 +1780,32 @@ class ClientTest extends TestCase
             ->andReturn('crc32');
 
         $this->assertEquals('crc32 ' . base64_encode($checksum), $this->tusClientMock->getUploadChecksumHeader());
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::getUploadMetadataHeader
+     */
+    public function it_gets_upload_metadata_header()
+    {
+        $filePath = __DIR__ . '/../Fixtures/empty.txt';
+
+        $this->tusClientMock->file($filePath);
+        $metadata = 'filename ' . base64_encode('empty.txt');
+
+        $this->assertEquals($metadata, $this->tusClientMock->getUploadMetadataHeader());
+
+        $this->tusClientMock->addMetadata('filename', 'test.txt');
+        $metadata = 'filename ' . base64_encode('test.txt');
+
+        $this->assertEquals($metadata, $this->tusClientMock->getUploadMetadataHeader());
+
+
+        $this->tusClientMock->addMetadata('filetype', 'plain/text');
+        $metadata .= ',filetype ' . base64_encode('plain/text');
+
+        $this->assertEquals($metadata, $this->tusClientMock->getUploadMetadataHeader());
     }
 
     /**


### PR DESCRIPTION
According to https://tus.io/protocols/resumable-upload.html#upload-metadata the Upload-Metadata header could contain multiple items.