### PR TITLE
Allow file creation without providing a filename in User-Metadata header

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -112,7 +112,8 @@ class Request
     }
 
     /**
-     * Extract base64 encoded filename from header.
+     * Extract base64 encoded filename from the header.
+     * If name and filename are not provided, fallback is created using uploadKey @see Server::handlePost()
      *
      * @return string
      */

--- a/src/Tus/Server.php
+++ b/src/Tus/Server.php
@@ -344,15 +344,16 @@ class Server extends AbstractTus
         $fileName   = $this->getRequest()->extractFileName();
         $uploadType = self::UPLOAD_TYPE_NORMAL;
 
-        if (empty($fileName)) {
-            return $this->response->send(null, HttpResponse::HTTP_BAD_REQUEST);
-        }
-
         if ( ! $this->verifyUploadSize()) {
             return $this->response->send(null, HttpResponse::HTTP_REQUEST_ENTITY_TOO_LARGE);
         }
 
         $uploadKey = $this->getUploadKey();
+
+        if (empty($fileName)) {
+            $fileName = $uploadKey;
+        }
+
         $filePath  = $this->uploadDir . DIRECTORY_SEPARATOR . $fileName;
 
         if ($this->getRequest()->isFinal()) {

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -141,7 +141,7 @@ class RequestTest extends TestCase
      * @covers ::extractMeta
      * @covers ::extractFileName
      */
-    public function it_extracts_file_name()
+    public function it_extracts_file_name_from_name_metadata()
     {
         $filename = 'file.txt';
 
@@ -178,6 +178,16 @@ class RequestTest extends TestCase
         $this->assertEquals($filename, $this->request->extractFileName());
         $this->assertEquals($fileType, $this->request->extractMeta('type'));
         $this->assertEquals($accept, $this->request->extractMeta('accept'));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::extractFileName
+     */
+    public function it_extracts_file_name_returns_empty_string_when_metadata_is_not_present()
+    {
+        $this->assertEquals('', $this->request->extractFileName());
     }
 
     /**


### PR DESCRIPTION
Even if the client doesn't send `User-Metadata` keys `name` and/or `filename` server should still be able to proceed with handling `POST` request.

In that case `uploadKey` UUID is used as a filename. 

More info can be found here
https://tus.io/protocols/resumable-upload.html#how-can-i-get-the-file-name-or-file-type-for-an-upload

If I'm reading it correctly, `tusd` implementation completely ignores `User-Metadata` header when creating a new file:
https://github.com/tus/tusd/blob/9c0d753f7dddedc1444178171add376cea91ec30/filestore/filestore.go#L62-L66

I think this is a nice feature and it can't hurt, 1 less `400 Bad request` to worry about