### PR TITLE
Save user sent metadata

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -46,6 +46,9 @@ class File
     /** @var int */
     protected $fileSize;
 
+    /** @var string[] */
+    protected $metaInfo = [];
+
     /**
      * File constructor.
      *
@@ -247,6 +250,24 @@ class File
     }
 
     /**
+     * @param string[] $metaInfo
+     * @return File
+     */
+    public function setMetaInfo(array $metaInfo): self
+    {
+        $this->metaInfo = $metaInfo;
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getMetaInfo(): array
+    {
+        return $this->metaInfo;
+    }
+
+    /**
      * Get input stream.
      *
      * @return string
@@ -265,7 +286,7 @@ class File
     {
         $now = Carbon::now();
 
-        return [
+        return array_merge($this->metaInfo, [
             'name' => $this->name,
             'size' => $this->fileSize,
             'offset' => $this->offset,
@@ -274,7 +295,7 @@ class File
             'file_path' => $this->filePath,
             'created_at' => $now->format($this->cache::RFC_7231),
             'expires_at' => $now->addSeconds($this->cache->getTtl())->format($this->cache::RFC_7231),
-        ];
+        ]);
     }
 
     /**

--- a/src/File.php
+++ b/src/File.php
@@ -507,7 +507,7 @@ class File
         $status = @copy($source, $destination);
 
         if (false === $status) {
-            throw new FileException('Cannot copy source to destination.');
+            throw new FileException(sprintf('Cannot copy source (%s) to destination (%s).', $source, $destination));
         }
 
         return $status;

--- a/src/File.php
+++ b/src/File.php
@@ -47,7 +47,7 @@ class File
     protected $fileSize;
 
     /** @var string[] */
-    private $metaInfo = [];
+    private $uploadMetadata = [];
 
     /**
      * File constructor.
@@ -250,12 +250,14 @@ class File
     }
 
     /**
-     * @param string[] $metaInfo
+     * @param string[] $metadata
+     *
      * @return File
      */
-    public function setMetaInfo(array $metaInfo): self
+    public function setUploadMetadata(array $metadata) : self
     {
-        $this->metaInfo = $metaInfo;
+        $this->uploadMetadata = $metadata;
+
         return $this;
     }
 
@@ -278,16 +280,17 @@ class File
     {
         $now = Carbon::now();
 
-        return array_merge($this->metaInfo, [
+        return [
             'name' => $this->name,
             'size' => $this->fileSize,
             'offset' => $this->offset,
             'checksum' => $this->checksum,
             'location' => $this->location,
             'file_path' => $this->filePath,
+            'metadata' => $this->uploadMetadata,
             'created_at' => $now->format($this->cache::RFC_7231),
             'expires_at' => $now->addSeconds($this->cache->getTtl())->format($this->cache::RFC_7231),
-        ]);
+        ];
     }
 
     /**

--- a/src/File.php
+++ b/src/File.php
@@ -47,7 +47,7 @@ class File
     protected $fileSize;
 
     /** @var string[] */
-    protected $metaInfo = [];
+    private $metaInfo = [];
 
     /**
      * File constructor.
@@ -257,14 +257,6 @@ class File
     {
         $this->metaInfo = $metaInfo;
         return $this;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getMetaInfo(): array
-    {
-        return $this->metaInfo;
     }
 
     /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -156,6 +156,31 @@ class Request
     }
 
     /**
+     * Extracts all meta data from the request header.
+     *
+     * @return string[]
+     */
+    public function extractAllMeta() : array
+    {
+        $uploadMetaData = $this->request->headers->get('Upload-Metadata');
+
+        if (empty($uploadMetaData)) {
+            return [];
+        }
+
+        $uploadMetaDataChunks = explode(',', $uploadMetaData);
+
+        $result = [];
+        foreach ($uploadMetaDataChunks as $chunk) {
+            list($key, $value) = explode(' ', $chunk);
+
+            $result[$key] = base64_decode($value);
+        }
+
+        return $result;
+    }
+
+    /**
      * Extract partials from header.
      *
      * @return array

--- a/src/Tus/Server.php
+++ b/src/Tus/Server.php
@@ -644,11 +644,6 @@ class Server extends AbstractTus
             $file->setMeta($meta['offset'], $meta['size'], $meta['file_path'], $meta['location']);
         }
 
-        $metaInfo = array_filter($meta, function ($key) {
-            return false === in_array($key, ['offset', 'size', 'file_path', 'location', 'name'], true);
-        }, ARRAY_FILTER_USE_KEY);
-        $file->setMetaInfo($metaInfo);
-
         return $file;
     }
 

--- a/src/Tus/Server.php
+++ b/src/Tus/Server.php
@@ -366,16 +366,14 @@ class Server extends AbstractTus
 
         $checksum = $this->getClientChecksum();
         $location = $this->getRequest()->url() . $this->getApiPath() . '/' . $uploadKey;
-        $metaInfo = $this->getRequest()->extractAllMeta();
 
-        $meta = array_merge($metaInfo, [
+        $file = $this->buildFile([
             'name' => $fileName,
             'offset' => 0,
             'size' => $this->getRequest()->header('Upload-Length'),
             'file_path' => $filePath,
             'location' => $location,
-        ]);
-        $file = $this->buildFile($meta)->setKey($uploadKey)->setChecksum($checksum);
+        ])->setKey($uploadKey)->setChecksum($checksum)->setUploadMetadata($this->getRequest()->extractAllMeta());
 
         $this->cache->set($uploadKey, $file->details() + ['upload_type' => $uploadType]);
 
@@ -410,15 +408,13 @@ class Server extends AbstractTus
         $filePaths = array_column($files, 'file_path');
         $location  = $this->getRequest()->url() . $this->getApiPath() . '/' . $uploadKey;
 
-        $metaInfo = $this->getRequest()->extractAllMeta();
-        $meta = array_merge($metaInfo, [
+        $file = $this->buildFile([
             'name' => $fileName,
             'offset' => 0,
             'size' => 0,
             'file_path' => $filePath,
             'location' => $location,
-        ]);
-        $file = $this->buildFile($meta)->setFilePath($filePath)->setKey($uploadKey);
+        ])->setFilePath($filePath)->setKey($uploadKey)->setUploadMetadata($this->getRequest()->extractAllMeta());
 
         $file->setOffset($file->merge($files));
 
@@ -470,7 +466,7 @@ class Server extends AbstractTus
             return $this->response->send(null, $status);
         }
 
-        $file     = $this->buildFile($meta);
+        $file     = $this->buildFile($meta)->setUploadMetadata($meta['metadata'] ?? []);
         $checksum = $meta['checksum'];
 
         try {

--- a/tests/FileTest.php
+++ b/tests/FileTest.php
@@ -491,7 +491,7 @@ class FileTest extends TestCase
      * @covers ::merge
      *
      * @expectedException \TusPhp\Exception\FileException
-     * @expectedExceptionMessageRegExp /Cannot copy source \(\S+\) to destination \(\S+\)\./
+     * @expectedExceptionMessageRegExp /Cannot copy source \(.+\) to destination \(.+\)\./
      */
     public function it_throws_file_exception_if_it_cannot_copy_file()
     {

--- a/tests/FileTest.php
+++ b/tests/FileTest.php
@@ -491,7 +491,7 @@ class FileTest extends TestCase
      * @covers ::merge
      *
      * @expectedException \TusPhp\Exception\FileException
-     * @expectedExceptionMessage Cannot copy source to destination.
+     * @expectedExceptionMessageRegExp /Cannot copy source \(\S+\) to destination \(\S+\)\./
      */
     public function it_throws_file_exception_if_it_cannot_copy_file()
     {

--- a/tests/Tus/ServerTest.php
+++ b/tests/Tus/ServerTest.php
@@ -892,7 +892,6 @@ class ServerTest extends TestCase
 
         $this->tusServerMock
             ->shouldReceive('getRequest')
-            ->times(6)
             ->andReturn($requestMock);
 
         $this->tusServerMock
@@ -1006,7 +1005,6 @@ class ServerTest extends TestCase
 
         $this->tusServerMock
             ->shouldReceive('getRequest')
-            ->times(6)
             ->andReturn($requestMock);
 
         $this->tusServerMock

--- a/tests/Tus/ServerTest.php
+++ b/tests/Tus/ServerTest.php
@@ -892,6 +892,8 @@ class ServerTest extends TestCase
 
         $this->tusServerMock
             ->shouldReceive('getRequest')
+            ->atLeast()
+            ->once()
             ->andReturn($requestMock);
 
         $this->tusServerMock
@@ -1006,6 +1008,8 @@ class ServerTest extends TestCase
 
         $this->tusServerMock
             ->shouldReceive('getRequest')
+            ->atLeast()
+            ->once()
             ->andReturn($requestMock);
 
         $this->tusServerMock
@@ -1127,6 +1131,8 @@ class ServerTest extends TestCase
 
         $this->tusServerMock
             ->shouldReceive('getRequest')
+            ->atLeast()
+            ->once()
             ->andReturn($requestMock);
 
         $cacheMock = m::mock(FileStore::class);
@@ -1283,6 +1289,8 @@ class ServerTest extends TestCase
 
         $this->tusServerMock
             ->shouldReceive('getRequest')
+            ->atLeast()
+            ->once()
             ->andReturn($requestMock);
 
         $cacheMock = m::mock(FileStore::class);

--- a/tests/Tus/ServerTest.php
+++ b/tests/Tus/ServerTest.php
@@ -1098,6 +1098,7 @@ class ServerTest extends TestCase
         ];
 
         $concatenatedFile = [
+            'filename' => $fileName,
             'name' => $fileName,
             'offset' => 0,
             'size' => 0,
@@ -1126,7 +1127,6 @@ class ServerTest extends TestCase
 
         $this->tusServerMock
             ->shouldReceive('getRequest')
-            ->times(4)
             ->andReturn($requestMock);
 
         $cacheMock = m::mock(FileStore::class);

--- a/tests/Tus/ServerTest.php
+++ b/tests/Tus/ServerTest.php
@@ -930,13 +930,15 @@ class ServerTest extends TestCase
             ->shouldReceive('set')
             ->once()
             ->with($partialKey, [
-                'filename' => $fileName,
                 'name' => $fileName,
                 'size' => 10,
                 'offset' => 0,
                 'checksum' => $checksum,
                 'location' => $location,
                 'file_path' => "$baseDir/$folder/$fileName",
+                'metadata' => [
+                    'filename' => $fileName,
+                ],
                 'created_at' => 'Fri, 08 Dec 2017 00:00:00 GMT',
                 'expires_at' => $expiresAt,
                 'upload_type' => 'partial',
@@ -1046,13 +1048,15 @@ class ServerTest extends TestCase
             ->shouldReceive('set')
             ->once()
             ->with($key, [
-                'filename' => $fileName,
                 'name' => $fileName,
                 'size' => 10,
                 'offset' => 0,
                 'checksum' => $checksum,
                 'location' => $location,
                 'file_path' => dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'uploads' . DIRECTORY_SEPARATOR . $fileName,
+                'metadata' => [
+                    'filename' => $fileName,
+                ],
                 'created_at' => 'Fri, 08 Dec 2017 00:00:00 GMT',
                 'expires_at' => $expiresAt,
                 'upload_type' => 'normal',
@@ -1102,7 +1106,6 @@ class ServerTest extends TestCase
         ];
 
         $concatenatedFile = [
-            'filename' => $fileName,
             'name' => $fileName,
             'offset' => 0,
             'size' => 0,
@@ -1208,6 +1211,14 @@ class ServerTest extends TestCase
             ->shouldReceive('setOffset')
             ->once()
             ->with(30)
+            ->andReturnSelf();
+
+        $fileMock
+            ->shouldReceive('setUploadMetadata')
+            ->once()
+            ->with([
+                'filename' => $fileName,
+            ])
             ->andReturnSelf();
 
         $fileMock
@@ -1320,7 +1331,6 @@ class ServerTest extends TestCase
             ->shouldReceive('buildFile')
             ->once()
             ->with([
-                'filename' => $fileName,
                 'name' => $fileName,
                 'offset' => 0,
                 'size' => 0,
@@ -1345,6 +1355,14 @@ class ServerTest extends TestCase
             ->shouldReceive('setOffset')
             ->once()
             ->with(30)
+            ->andReturnSelf();
+
+        $fileMock
+            ->shouldReceive('setUploadMetadata')
+            ->once()
+            ->with([
+                'filename' => $fileName,
+            ])
             ->andReturnSelf();
 
         $fileMock
@@ -1425,6 +1443,9 @@ class ServerTest extends TestCase
             'offset' => 0,
             'checksum' => $checksum,
             'file_path' => dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName,
+            'metadata' => [
+                'filename' => $fileName,
+            ],
             'location' => $location,
             'created_at' => 'Fri, 08 Dec 2017 00:00:00 GMT',
             'expires_at' => $expiresAt,
@@ -1487,6 +1508,9 @@ class ServerTest extends TestCase
             'offset' => 0,
             'checksum' => $checksum,
             'file_path' => dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName,
+            'metadata' => [
+                'filename' => $fileName,
+            ],
             'location' => $location,
             'created_at' => 'Fri, 08 Dec 2017 00:00:00 GMT',
             'expires_at' => $expiresAt,
@@ -1519,6 +1543,14 @@ class ServerTest extends TestCase
             ->shouldReceive('setChecksum')
             ->once()
             ->with($checksum)
+            ->andReturnSelf();
+
+        $fileMock
+            ->shouldReceive('setUploadMetadata')
+            ->once()
+            ->with([
+                'filename' => $fileName,
+            ])
             ->andReturnSelf();
 
         $fileMock
@@ -1579,6 +1611,9 @@ class ServerTest extends TestCase
             'offset' => 0,
             'checksum' => $checksum,
             'file_path' => dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName,
+            'metadata' => [
+                'filename' => $fileName,
+            ],
             'location' => $location,
             'created_at' => 'Fri, 08 Dec 2017 00:00:00 GMT',
             'expires_at' => $expiresAt,
@@ -1611,6 +1646,14 @@ class ServerTest extends TestCase
             ->shouldReceive('setChecksum')
             ->once()
             ->with($checksum)
+            ->andReturnSelf();
+
+        $fileMock
+            ->shouldReceive('setUploadMetadata')
+            ->once()
+            ->with([
+                'filename' => $fileName,
+            ])
             ->andReturnSelf();
 
         $fileMock
@@ -1671,6 +1714,9 @@ class ServerTest extends TestCase
             'offset' => 0,
             'checksum' => $checksum,
             'file_path' => dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName,
+            'metadata' => [
+                'filename' => $fileName,
+            ],
             'location' => $location,
             'created_at' => 'Fri, 08 Dec 2017 00:00:00 GMT',
             'expires_at' => $expiresAt,
@@ -1697,6 +1743,14 @@ class ServerTest extends TestCase
             ->shouldReceive('setChecksum')
             ->once()
             ->with($checksum)
+            ->andReturnSelf();
+
+        $fileMock
+            ->shouldReceive('setUploadMetadata')
+            ->once()
+            ->with([
+                'filename' => $fileName,
+            ])
             ->andReturnSelf();
 
         $fileMock
@@ -1761,6 +1815,9 @@ class ServerTest extends TestCase
             'size' => $fileSize,
             'offset' => 0,
             'file_path' => dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName,
+            'metadata' => [
+                'filename' => $fileName,
+            ],
             'location' => $location,
             'created_at' => 'Fri, 08 Dec 2017 00:00:00 GMT',
             'expires_at' => $expiresAt,
@@ -1817,6 +1874,9 @@ class ServerTest extends TestCase
             'offset' => 0,
             'checksum' => $checksum,
             'file_path' => __DIR__ . '/../Fixtures/empty.txt',
+            'metadata' => [
+                'filename' => $fileName,
+            ],
             'location' => $location,
             'created_at' => 'Fri, 08 Dec 2017 00:00:00 GMT',
             'expires_at' => $expiresAt,
@@ -1849,6 +1909,14 @@ class ServerTest extends TestCase
             ->shouldReceive('setChecksum')
             ->once()
             ->with($checksum)
+            ->andReturnSelf();
+
+        $fileMock
+            ->shouldReceive('setUploadMetadata')
+            ->once()
+            ->with([
+                'filename' => $fileName,
+            ])
             ->andReturnSelf();
 
         $fileMock
@@ -1910,6 +1978,9 @@ class ServerTest extends TestCase
             'offset' => 0,
             'checksum' => $checksum,
             'file_path' => __DIR__ . '/../Fixtures/empty.txt',
+            'metadata' => [
+                'filename' => $fileName,
+            ],
             'location' => $location,
             'created_at' => 'Fri, 08 Dec 2017 00:00:00 GMT',
             'expires_at' => $expiresAt,
@@ -1942,6 +2013,14 @@ class ServerTest extends TestCase
             ->shouldReceive('setChecksum')
             ->once()
             ->with($checksum)
+            ->andReturnSelf();
+
+        $fileMock
+            ->shouldReceive('setUploadMetadata')
+            ->once()
+            ->with([
+                'filename' => $fileName,
+            ])
             ->andReturnSelf();
 
         $fileMock
@@ -2023,6 +2102,9 @@ class ServerTest extends TestCase
             'offset' => 0,
             'checksum' => $checksum,
             'file_path' => dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName,
+            'metadata' => [
+                'filename' => $fileName,
+            ],
             'location' => $location,
             'created_at' => 'Fri, 08 Dec 2017 00:00:00 GMT',
             'expires_at' => $expiresAt,
@@ -2055,6 +2137,14 @@ class ServerTest extends TestCase
             ->shouldReceive('setChecksum')
             ->once()
             ->with($checksum)
+            ->andReturnSelf();
+
+        $fileMock
+            ->shouldReceive('setUploadMetadata')
+            ->once()
+            ->with([
+                'filename' => $fileName,
+            ])
             ->andReturnSelf();
 
         $fileMock
@@ -2322,6 +2412,9 @@ class ServerTest extends TestCase
             'size' => $fileSize,
             'offset' => 0,
             'file_path' => __DIR__ . '/../Fixtures/empty.txt',
+            'metadata' => [
+                'filename' => $fileName,
+            ],
             'location' => $location,
             'created_at' => 'Fri, 08 Dec 2017 00:00:00 GMT',
             'expires_at' => $expiresAt,
@@ -3064,6 +3157,9 @@ class ServerTest extends TestCase
             'offset' => 0,
             'checksum' => $checksum,
             'file_path' => dirname(__DIR__) . DIRECTORY_SEPARATOR . $fileName,
+            'metadata' => [
+                'filename' => $fileName,
+            ],
             'location' => $location,
             'created_at' => 'Fri, 08 Dec 2017 00:00:00 GMT',
             'expires_at' => $expiresAt,

--- a/tests/Tus/ServerTest.php
+++ b/tests/Tus/ServerTest.php
@@ -928,6 +928,7 @@ class ServerTest extends TestCase
             ->shouldReceive('set')
             ->once()
             ->with($partialKey, [
+                'filename' => $fileName,
                 'name' => $fileName,
                 'size' => 10,
                 'offset' => 0,
@@ -1041,6 +1042,7 @@ class ServerTest extends TestCase
             ->shouldReceive('set')
             ->once()
             ->with($key, [
+                'filename' => $fileName,
                 'name' => $fileName,
                 'size' => 10,
                 'offset' => 0,

--- a/tests/Tus/ServerTest.php
+++ b/tests/Tus/ServerTest.php
@@ -1283,7 +1283,6 @@ class ServerTest extends TestCase
 
         $this->tusServerMock
             ->shouldReceive('getRequest')
-            ->times(4)
             ->andReturn($requestMock);
 
         $cacheMock = m::mock(FileStore::class);
@@ -1313,6 +1312,7 @@ class ServerTest extends TestCase
             ->shouldReceive('buildFile')
             ->once()
             ->with([
+                'filename' => $fileName,
                 'name' => $fileName,
                 'offset' => 0,
                 'size' => 0,


### PR DESCRIPTION
Fixes #163.

I needed this functionality more or less, so I've given a crack at it. 

Screenshot below is from Symfony dump for file upload completion event, which previously did not contain any user sent metadata.

![2019-07-16_19-20](https://user-images.githubusercontent.com/3183926/61315292-be6f2e80-a7fe-11e9-9c42-3ca9ca690f17.png)

There are no tests yet added, wanted to have your opinion on this approach first.