### PR TITLE
Remove iconv filename fallback. Prefer using Symfony built-in.

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -133,8 +133,7 @@ class Response
         if ( ! is_null($name)) {
             $response = $response->setContentDisposition(
                 $disposition,
-                $name,
-                iconv('UTF-8', 'ASCII//TRANSLIT', $name)
+                $name
             );
         }
 


### PR DESCRIPTION
Fixes #165.

Actually, there was no dependency on `iconv` in composer.