### PR TITLE
Add support of the cloud providers storages

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -20,7 +20,7 @@ class File
     const READ_BINARY = 'rb';
 
     /** @const Append binary mode */
-    const APPEND_BINARY = 'ab+';
+    const APPEND_BINARY = 'ab';
 
     /** @var string */
     protected $key;

--- a/src/Tus/Server.php
+++ b/src/Tus/Server.php
@@ -84,7 +84,7 @@ class Server extends AbstractTus
         $this->request    = new Request;
         $this->response   = new Response;
         $this->middleware = new Middleware;
-        $this->uploadDir  = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'uploads';
+        $this->uploadDir  = dirname(__DIR__, 2) . '/' . 'uploads';
 
         $this->setCache($cacheAdapter);
     }
@@ -353,7 +353,7 @@ class Server extends AbstractTus
         }
 
         $uploadKey = $this->getUploadKey();
-        $filePath  = $this->uploadDir . DIRECTORY_SEPARATOR . $fileName;
+        $filePath  = $this->uploadDir . '/' . $fileName;
 
         if ($this->getRequest()->isFinal()) {
             return $this->handleConcatenation($fileName, $filePath);
@@ -721,7 +721,7 @@ class Server extends AbstractTus
     {
         list($actualKey, /* $partialUploadKey */) = explode(self::PARTIAL_UPLOAD_NAME_SEPARATOR, $key);
 
-        $path = $this->uploadDir . DIRECTORY_SEPARATOR . $actualKey . DIRECTORY_SEPARATOR;
+        $path = $this->uploadDir . '/' . $actualKey . '/';
 
         if ( ! file_exists($path)) {
             mkdir($path);


### PR DESCRIPTION
Currently, TUS PHP does not work with stream wrappers from cloud providers such as [AWS S3](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/s3-stream-wrapper.html).

This pull request makes TUS PHP compatible with stream wrappers and cloud providers storages.

Regarding `DIRECTORY_SEPARATOR`, there is no need to use (for this use case) it since Windows handles the slash for directories very well.

Regarding `APPEND_BINARY`, the cloud provider storages can only open a read or write stream, but not both.