### PR TITLE
Fixed getClientChecksum function

### DIFF
--- a/src/Tus/Server.php
+++ b/src/Tus/Server.php
@@ -683,8 +683,6 @@ class Server extends AbstractTus
 
         list($checksumAlgorithm, $checksum) = explode(' ', $checksumHeader);
 
-        $checksum = base64_decode($checksum);
-
         if ( ! in_array($checksumAlgorithm, hash_algos()) || false === $checksum) {
             return $this->response->send(null, HttpResponse::HTTP_BAD_REQUEST);
         }


### PR DESCRIPTION
$checksum is not been base64_encode, but when there get it, it use base64_decode.