### PR TITLE
add xdebug to tus-base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,14 @@ Since the server supports tus expiration extension, a cron job is set to run onc
     $ ./vendor/bin/php-cs-fixer fix <changes> --rules=@PSR2,not_operator_with_space,single_quote
     ```
 
+_Note:_ There is an extra command `composer test-coverage` that will generate coverage
+at project root. You can open `coverage/index.html` to checkout coverage report.
+
+```shell
+# Command to Generate Coverage
+$ docker exec tus-php-server composer test-coverage
+```
+
 ### Questions about this project?
 Please feel free to report any bug found. Pull requests, issues, and project recommendations are more than welcome!
 

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
   },
   "scripts": {
     "test": "phpunit",
-    "cs-fixer": "php-cs-fixer fix src/ --rules=@PSR2,not_operator_with_space,single_quote"
+    "test-coverage": "vendor/bin/phpunit --coverage-html ./coverage",
+    "cs-fixer": "vendor/bin/php-cs-fixer fix src/ --rules=@PSR2,not_operator_with_space,single_quote"
   },
   "bin": [
     "bin/tus"

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -21,6 +21,9 @@ RUN apk add --no-cache \
 ## Composer installation
 RUN apk add --no-cache php7.2-pcntl composer
 
+## Xdebug Installation
+RUN apk add --no-cache php7.2-xdebug
+
 COPY ./configs/nginx.conf /etc/nginx/nginx.conf
 
 ENV PHP_INI_DIR /etc/php/7.2

--- a/docker/base/configs/php.ini
+++ b/docker/base/configs/php.ini
@@ -8,7 +8,6 @@ output_buffering = 4096
 zlib.output_compression = Off
 implicit_flush = Off
 serialize_precision = -1
-open_basedir = "/var/www:/tmp"
 disable_functions = exec,passthru,shell_exec,system,popen,parse_ini_file,show_source
 zend.enable_gc = On
 expose_php = Off


### PR DESCRIPTION
I have made some improvement on tus-base image to run unit test coverage and allow generate of unit test coverage. This is helpful in cases where we use CI tools for code coverage.

### **[Changes]**

- added xdebug to tus-base image.
- removed open_basedir restriction from *php.ini* which is ok for local development purpose.
- added command `test-coverage` which we can run as `composer test-coverage`

#### Docker command

```bash
$ docker exec tus-php-server composer test-coverage
```