### PR TITLE
Allow for request to be set on the server

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -21,6 +21,19 @@ class Request
     }
 
     /**
+     * Set the request
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \TusPhp\Request
+     */
+    public function setRequest(HttpRequest $request): self
+    {
+        $this->request = $request;
+
+        return $this;
+    }
+
+    /**
      * Get http method from current request.
      *
      * @return string

--- a/src/Tus/Server.php
+++ b/src/Tus/Server.php
@@ -17,6 +17,7 @@ use TusPhp\Exception\FileException;
 use TusPhp\Exception\ConnectionException;
 use TusPhp\Exception\OutOfRangeException;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\HttpFoundation\Response as HttpResponse;
 
 class Server extends AbstractTus
@@ -87,6 +88,19 @@ class Server extends AbstractTus
         $this->uploadDir  = dirname(__DIR__, 2) . '/' . 'uploads';
 
         $this->setCache($cacheAdapter);
+    }
+
+    /**
+     * Set the request
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \TusPhp\Tus\Server
+     */
+    public function setRequest(HttpRequest $request): self
+    {
+        $this->request->setRequest($request);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
I have a working Laravel integration with some fairly involved image processing steps happening in the `completed` event. Now, I am testing the separate steps independently and those work fine, but I also wanted to test a full upload. For this, I first resorted to using the Tus client. While this worked, it was kinda clunky as this involved actual HTTP requests via Guzzle. So, I then created the requests manually using Laravels HTTP testing only to discover that the Tus server sets any request method to `GET` as it has no knowledge of how Laravel sets up its testing request. The solution to this is to allow to set the request manually on the server.

I've just added two simple setters that don't require any additional tests in my opinion. I would appreciate it if you would merge this request. Thanks!