### PR TITLE
Add PHP-CS-Fixer config, use native_function_invocation option only for compiler optimized methods

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,14 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()->in(['src', 'tests']);
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@PSR2' => true,
+        'not_operator_with_space' => true,
+        'single_quote' => true,
+        'binary_operator_spaces' => ['align_equals' => true],
+        'native_function_invocation' => ['include' => ['@compiler_optimized']],
+    ])
+    ->setRiskyAllowed(true)
+    ->setFinder($finder);

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ Since the server supports tus expiration extension, a cron job is set to run onc
 
     # or
 
-    $ ./vendor/bin/php-cs-fixer fix <changes> --rules=@PSR2,not_operator_with_space,single_quote
+    $ ./vendor/bin/php-cs-fixer fix <changes>
     ```
 
 _Note:_ There is an extra command `composer test-coverage` that will generate coverage

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
   "scripts": {
     "test": "phpunit",
     "test-coverage": "vendor/bin/phpunit --coverage-html ./coverage",
-    "cs-fixer": "vendor/bin/php-cs-fixer fix src/ --rules=@PSR2,not_operator_with_space,single_quote"
+    "cs-fixer": "vendor/bin/php-cs-fixer fix"
   },
   "bin": [
     "bin/tus"

--- a/src/Cache/FileStore.php
+++ b/src/Cache/FileStore.php
@@ -84,8 +84,8 @@ class FileStore extends AbstractCache
      */
     protected function createCacheDir()
     {
-        if ( ! \file_exists($this->cacheDir)) {
-            \mkdir($this->cacheDir);
+        if ( ! file_exists($this->cacheDir)) {
+            mkdir($this->cacheDir);
         }
     }
 
@@ -100,8 +100,8 @@ class FileStore extends AbstractCache
 
         $cacheFilePath = $this->getCacheFile();
 
-        if ( ! \file_exists($cacheFilePath)) {
-            \touch($cacheFilePath);
+        if ( ! file_exists($cacheFilePath)) {
+            touch($cacheFilePath);
         }
     }
 
@@ -134,22 +134,22 @@ class FileStore extends AbstractCache
     public function sharedGet(string $path) : string
     {
         $contents = '';
-        $handle   = @\fopen($path, File::READ_BINARY);
+        $handle   = @fopen($path, File::READ_BINARY);
 
         if (false === $handle) {
             return $contents;
         }
 
         try {
-            if (\flock($handle, LOCK_SH)) {
-                \clearstatcache(true, $path);
+            if (flock($handle, LOCK_SH)) {
+                clearstatcache(true, $path);
 
-                $contents = fread($handle, \filesize($path) ?: 1);
+                $contents = fread($handle, filesize($path) ?: 1);
 
-                \flock($handle, LOCK_UN);
+                flock($handle, LOCK_UN);
             }
         } finally {
-            \fclose($handle);
+            fclose($handle);
         }
 
         return $contents;
@@ -165,7 +165,7 @@ class FileStore extends AbstractCache
      */
     public function put(string $path, string $contents) : int
     {
-        return \file_put_contents($path, $contents, LOCK_EX);
+        return file_put_contents($path, $contents, LOCK_EX);
     }
 
     /**
@@ -176,11 +176,11 @@ class FileStore extends AbstractCache
         $cacheKey  = $this->getActualCacheKey($key);
         $cacheFile = $this->getCacheFile();
 
-        if ( ! \file_exists($cacheFile) || ! $this->isValid($cacheKey)) {
+        if ( ! file_exists($cacheFile) || ! $this->isValid($cacheKey)) {
             $this->createCacheFile();
         }
 
-        $contents = \json_decode($this->sharedGet($cacheFile), true) ?? [];
+        $contents = json_decode($this->sharedGet($cacheFile), true) ?? [];
 
         if ( ! empty($contents[$cacheKey]) && \is_array($value)) {
             $contents[$cacheKey] = $value + $contents[$cacheKey];
@@ -188,7 +188,7 @@ class FileStore extends AbstractCache
             $contents[$cacheKey] = $value;
         }
 
-        return $this->put($cacheFile, \json_encode($contents));
+        return $this->put($cacheFile, json_encode($contents));
     }
 
     /**
@@ -202,7 +202,7 @@ class FileStore extends AbstractCache
         if (isset($contents[$cacheKey])) {
             unset($contents[$cacheKey]);
 
-            return false !== $this->put($this->getCacheFile(), \json_encode($contents));
+            return false !== $this->put($this->getCacheFile(), json_encode($contents));
         }
 
         return false;
@@ -216,7 +216,7 @@ class FileStore extends AbstractCache
         $contents = $this->getCacheContents();
 
         if (\is_array($contents)) {
-            return \array_keys($contents);
+            return array_keys($contents);
         }
 
         return [];
@@ -250,11 +250,11 @@ class FileStore extends AbstractCache
     {
         $cacheFile = $this->getCacheFile();
 
-        if ( ! \file_exists($cacheFile)) {
+        if ( ! file_exists($cacheFile)) {
             return false;
         }
 
-        return \json_decode($this->sharedGet($cacheFile), true) ?? [];
+        return json_decode($this->sharedGet($cacheFile), true) ?? [];
     }
 
     /**
@@ -268,7 +268,7 @@ class FileStore extends AbstractCache
     {
         $prefix = $this->getPrefix();
 
-        if (false === \strpos($key, $prefix)) {
+        if (false === strpos($key, $prefix)) {
             $key = $prefix . $key;
         }
 

--- a/src/Cache/RedisStore.php
+++ b/src/Cache/RedisStore.php
@@ -40,12 +40,12 @@ class RedisStore extends AbstractCache
     {
         $prefix = $this->getPrefix();
 
-        if (false === \strpos($key, $prefix)) {
+        if (false === strpos($key, $prefix)) {
             $key = $prefix . $key;
         }
 
         $contents = $this->redis->get($key);
-        $contents = \json_decode($contents, true);
+        $contents = json_decode($contents, true);
 
         if ($withExpired) {
             return $contents;
@@ -66,10 +66,10 @@ class RedisStore extends AbstractCache
         if (\is_array($value)) {
             $contents = $value + $contents;
         } else {
-            \array_push($contents, $value);
+            array_push($contents, $value);
         }
 
-        $status = $this->redis->set($this->getPrefix() . $key, \json_encode($contents));
+        $status = $this->redis->set($this->getPrefix() . $key, json_encode($contents));
 
         return 'OK' === $status->getPayload();
     }
@@ -81,7 +81,7 @@ class RedisStore extends AbstractCache
     {
         $prefix = $this->getPrefix();
 
-        if (false === \strpos($key, $prefix)) {
+        if (false === strpos($key, $prefix)) {
             $key = $prefix . $key;
         }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -46,7 +46,7 @@ class Config
             return self::$config;
         }
 
-        $keys  = \explode('.', $key);
+        $keys  = explode('.', $key);
         $value = self::$config;
 
         foreach ($keys as $key) {

--- a/src/Config/client.php
+++ b/src/Config/client.php
@@ -6,9 +6,9 @@ return [
      * Redis connection parameters.
      */
     'redis' => [
-        'host' => \getenv('REDIS_HOST') !== false ? \getenv('REDIS_HOST') : '127.0.0.1',
-        'port' => \getenv('REDIS_PORT') !== false ? \getenv('REDIS_PORT') : '6379',
-        'database' => \getenv('REDIS_DB') !== false ? \getenv('REDIS_DB') : 0,
+        'host' => getenv('REDIS_HOST') !== false ? getenv('REDIS_HOST') : '127.0.0.1',
+        'port' => getenv('REDIS_PORT') !== false ? getenv('REDIS_PORT') : '6379',
+        'database' => getenv('REDIS_DB') !== false ? getenv('REDIS_DB') : 0,
     ],
 
     /**

--- a/src/Config/server.php
+++ b/src/Config/server.php
@@ -6,9 +6,9 @@ return [
      * Redis connection parameters.
      */
     'redis' => [
-        'host' => \getenv('REDIS_HOST') !== false ? \getenv('REDIS_HOST') : '127.0.0.1',
-        'port' => \getenv('REDIS_PORT') !== false ? \getenv('REDIS_PORT') : '6379',
-        'database' => \getenv('REDIS_DB') !== false ? \getenv('REDIS_DB') : 0,
+        'host' => getenv('REDIS_HOST') !== false ? getenv('REDIS_HOST') : '127.0.0.1',
+        'port' => getenv('REDIS_PORT') !== false ? getenv('REDIS_PORT') : '6379',
+        'database' => getenv('REDIS_DB') !== false ? getenv('REDIS_DB') : 0,
     ],
 
     /**

--- a/src/File.php
+++ b/src/File.php
@@ -315,7 +315,7 @@ class File
         try {
             $this->seek($output, $this->offset);
 
-            while ( ! \feof($input)) {
+            while ( ! feof($input)) {
                 if (CONNECTION_NORMAL !== connection_status()) {
                     throw new ConnectionException('Connection aborted by user.');
                 }
@@ -357,7 +357,7 @@ class File
     {
         $this->exists($filePath, $mode);
 
-        $ptr = @\fopen($filePath, $mode);
+        $ptr = @fopen($filePath, $mode);
 
         if (false === $ptr) {
             throw new FileException("Unable to open $filePath.");
@@ -382,7 +382,7 @@ class File
             return true;
         }
 
-        if (self::READ_BINARY === $mode && ! \file_exists($filePath)) {
+        if (self::READ_BINARY === $mode && ! file_exists($filePath)) {
             throw new FileException('File not found.');
         }
 
@@ -464,22 +464,22 @@ class File
     public function merge(array $files) : int
     {
         $destination = $this->getFilePath();
-        $firstFile   = \array_shift($files);
+        $firstFile   = array_shift($files);
 
         // First partial file can directly be copied.
         $this->copy($firstFile['file_path'], $destination);
 
         $this->offset   = $firstFile['offset'];
-        $this->fileSize = \filesize($firstFile['file_path']);
+        $this->fileSize = filesize($firstFile['file_path']);
 
         $handle = $this->open($destination, self::APPEND_BINARY);
 
         foreach ($files as $file) {
-            if ( ! \file_exists($file['file_path'])) {
+            if ( ! file_exists($file['file_path'])) {
                 throw new FileException('File to be merged not found.');
             }
 
-            $this->fileSize += $this->write($handle, \file_get_contents($file['file_path']));
+            $this->fileSize += $this->write($handle, file_get_contents($file['file_path']));
 
             $this->offset += $file['offset'];
         }
@@ -499,10 +499,10 @@ class File
      */
     public function copy(string $source, string $destination) : bool
     {
-        $status = @\copy($source, $destination);
+        $status = @copy($source, $destination);
 
         if (false === $status) {
-            throw new FileException(\sprintf('Cannot copy source (%s) to destination (%s).', $source, $destination));
+            throw new FileException(sprintf('Cannot copy source (%s) to destination (%s).', $source, $destination));
         }
 
         return $status;
@@ -521,7 +521,7 @@ class File
         $status = $this->deleteFiles($files);
 
         if ($status && $folder) {
-            return \rmdir(\dirname(\current($files)));
+            return rmdir(\dirname(current($files)));
         }
 
         return $status;
@@ -543,7 +543,7 @@ class File
         $status = true;
 
         foreach ($files as $file) {
-            if (\file_exists($file)) {
+            if (file_exists($file)) {
                 $status = $status && unlink($file);
             }
         }
@@ -560,6 +560,6 @@ class File
      */
     public function close($handle) : bool
     {
-        return \fclose($handle);
+        return fclose($handle);
     }
 }

--- a/src/Middleware/Cors.php
+++ b/src/Middleware/Cors.php
@@ -17,7 +17,7 @@ class Cors implements TusMiddleware
     {
         $response->setHeaders([
             'Access-Control-Allow-Origin' => $request->header('Origin'),
-            'Access-Control-Allow-Methods' => \implode(',', $request->allowedHttpVerbs()),
+            'Access-Control-Allow-Methods' => implode(',', $request->allowedHttpVerbs()),
             'Access-Control-Allow-Headers' => 'Origin, X-Requested-With, Content-Type, Content-Length, Upload-Key, Upload-Checksum, Upload-Length, Upload-Offset, Tus-Version, Tus-Resumable, Upload-Metadata',
             'Access-Control-Expose-Headers' => 'Upload-Key, Upload-Checksum, Upload-Length, Upload-Offset, Upload-Metadata, Tus-Version, Tus-Resumable, Tus-Extension, Location',
             'Access-Control-Max-Age' => self::HEADER_ACCESS_CONTROL_MAX_AGE,

--- a/src/Request.php
+++ b/src/Request.php
@@ -47,7 +47,7 @@ class Request
      */
     public function key() : string
     {
-        return \basename($this->path());
+        return basename($this->path());
     }
 
     /**
@@ -87,7 +87,7 @@ class Request
      */
     public function url() : string
     {
-        return \rtrim($this->request->getUriForPath('/'), '/');
+        return rtrim($this->request->getUriForPath('/'), '/');
     }
 
     /**
@@ -102,10 +102,10 @@ class Request
     {
         $meta = $this->header($key);
 
-        if (false !== \strpos($meta, $value)) {
-            $meta = \trim(\str_replace($value, '', $meta));
+        if (false !== strpos($meta, $value)) {
+            $meta = trim(str_replace($value, '', $meta));
 
-            return \explode(' ', $meta) ?? [];
+            return explode(' ', $meta) ?? [];
         }
 
         return [];
@@ -142,10 +142,10 @@ class Request
             return '';
         }
 
-        $uploadMetaDataChunks = \explode(',', $uploadMetaData);
+        $uploadMetaDataChunks = explode(',', $uploadMetaData);
 
         foreach ($uploadMetaDataChunks as $chunk) {
-            list($key, $value) = \explode(' ', $chunk);
+            list($key, $value) = explode(' ', $chunk);
 
             if ($key === $requestedKey) {
                 return base64_decode($value);
@@ -168,11 +168,11 @@ class Request
             return [];
         }
 
-        $uploadMetaDataChunks = \explode(',', $uploadMetaData);
+        $uploadMetaDataChunks = explode(',', $uploadMetaData);
 
         $result = [];
         foreach ($uploadMetaDataChunks as $chunk) {
-            list($key, $value) = \explode(' ', $chunk);
+            list($key, $value) = explode(' ', $chunk);
 
             $result[$key] = base64_decode($value);
         }
@@ -207,7 +207,7 @@ class Request
      */
     public function isFinal() : bool
     {
-        return false !== \strpos($this->header('Upload-Concat'), Server::UPLOAD_TYPE_FINAL . ';');
+        return false !== strpos($this->header('Upload-Concat'), Server::UPLOAD_TYPE_FINAL . ';');
     }
 
     /**
@@ -232,7 +232,7 @@ class Request
         $forbidden = ['../', '"', "'", '&', '/', '\\', '?', '#', ':'];
 
         foreach ($forbidden as $char) {
-            if (false !== \strpos($filename, $char)) {
+            if (false !== strpos($filename, $char)) {
                 return false;
             }
         }

--- a/src/Response.php
+++ b/src/Response.php
@@ -99,10 +99,10 @@ class Response
      */
     public function send($content, int $status = HttpResponse::HTTP_OK, array $headers = []) : HttpResponse
     {
-        $headers = \array_merge($this->headers, $headers);
+        $headers = array_merge($this->headers, $headers);
 
         if (\is_array($content)) {
-            $content = \json_encode($content);
+            $content = json_encode($content);
         }
 
         $response = $this->response->create($content, $status, $headers);

--- a/src/Tus/AbstractTus.php
+++ b/src/Tus/AbstractTus.php
@@ -52,7 +52,7 @@ abstract class AbstractTus
             $this->cache = $cache;
         }
 
-        $prefix = 'tus:' . \strtolower((new \ReflectionClass(static::class))->getShortName()) . ':';
+        $prefix = 'tus:' . strtolower((new \ReflectionClass(static::class))->getShortName()) . ':';
 
         $this->cache->setPrefix($prefix);
 

--- a/src/Tus/Client.php
+++ b/src/Tus/Client.php
@@ -84,12 +84,12 @@ class Client extends AbstractTus
     {
         $this->filePath = $file;
 
-        if ( ! \file_exists($file) || ! is_readable($file)) {
+        if ( ! file_exists($file) || ! is_readable($file)) {
             throw new FileException('Cannot read file: ' . $file);
         }
 
-        $this->fileName = $name ?? \basename($this->filePath);
-        $this->fileSize = \filesize($file);
+        $this->fileName = $name ?? basename($this->filePath);
+        $this->fileSize = filesize($file);
 
         $this->addMetadata('filename', $this->fileName);
 
@@ -172,7 +172,7 @@ class Client extends AbstractTus
     public function getChecksum() : string
     {
         if (empty($this->checksum)) {
-            $this->setChecksum(\hash_file($this->getChecksumAlgorithm(), $this->getFilePath()));
+            $this->setChecksum(hash_file($this->getChecksumAlgorithm(), $this->getFilePath()));
         }
 
         return $this->checksum;
@@ -216,7 +216,7 @@ class Client extends AbstractTus
      */
     public function setMetadata(array $items) : self
     {
-        $items = \array_map('base64_encode', $items);
+        $items = array_map('base64_encode', $items);
 
         $this->metadata = $items;
 
@@ -246,7 +246,7 @@ class Client extends AbstractTus
             $metadata[] = "{$key} {$value}";
         }
 
-        return \implode(',', $metadata);
+        return implode(',', $metadata);
     }
 
     /**
@@ -443,7 +443,7 @@ class Client extends AbstractTus
             throw new FileException('Unable to create resource.');
         }
 
-        $uploadLocation = \current($response->getHeader('location'));
+        $uploadLocation = current($response->getHeader('location'));
 
         $this->getCache()->set($this->getKey(), [
             'location' => $uploadLocation,
@@ -469,11 +469,11 @@ class Client extends AbstractTus
                 'Upload-Key' => $key,
                 'Upload-Checksum' => $this->getUploadChecksumHeader(),
                 'Upload-Metadata' => $this->getUploadMetadataHeader(),
-                'Upload-Concat' => self::UPLOAD_TYPE_FINAL . ';' . \implode(' ', $partials),
+                'Upload-Concat' => self::UPLOAD_TYPE_FINAL . ';' . implode(' ', $partials),
             ],
         ]);
 
-        $data       = \json_decode($response->getBody(), true);
+        $data       = json_decode($response->getBody(), true);
         $checksum   = $data['data']['checksum'] ?? null;
         $statusCode = $response->getStatusCode();
 
@@ -521,8 +521,8 @@ class Client extends AbstractTus
 
         $key = $this->getKey();
 
-        if (false !== \strpos($key, self::PARTIAL_UPLOAD_NAME_SEPARATOR)) {
-            list($key, /* $partialKey */) = \explode(self::PARTIAL_UPLOAD_NAME_SEPARATOR, $key);
+        if (false !== strpos($key, self::PARTIAL_UPLOAD_NAME_SEPARATOR)) {
+            list($key, /* $partialKey */) = explode(self::PARTIAL_UPLOAD_NAME_SEPARATOR, $key);
         }
 
         $this->key = $key . self::PARTIAL_UPLOAD_NAME_SEPARATOR . Uuid::uuid4()->toString();
@@ -544,7 +544,7 @@ class Client extends AbstractTus
             throw new FileException('File not found.');
         }
 
-        return (int) \current($response->getHeader('upload-offset'));
+        return (int) current($response->getHeader('upload-offset'));
     }
 
     /**
@@ -580,7 +580,7 @@ class Client extends AbstractTus
                 'headers' => $headers,
             ]);
 
-            return (int) \current($response->getHeader('upload-offset'));
+            return (int) current($response->getHeader('upload-offset'));
         } catch (ClientException $e) {
             throw $this->handleClientException($e);
         } catch (ConnectException $e) {

--- a/src/Tus/Server.php
+++ b/src/Tus/Server.php
@@ -142,7 +142,7 @@ class Server extends AbstractTus
      */
     public function getServerChecksum(string $filePath) : string
     {
-        return \hash_file($this->getChecksumAlgorithm(), $filePath);
+        return hash_file($this->getChecksumAlgorithm(), $filePath);
     }
 
     /**
@@ -158,7 +158,7 @@ class Server extends AbstractTus
             return self::DEFAULT_CHECKSUM_ALGORITHM;
         }
 
-        list($checksumAlgorithm, /* $checksum */) = \explode(' ', $checksumHeader);
+        list($checksumAlgorithm, /* $checksum */) = explode(' ', $checksumHeader);
 
         return $checksumAlgorithm;
     }
@@ -270,7 +270,7 @@ class Server extends AbstractTus
             ]);
         }
 
-        $method = 'handle' . \ucfirst(\strtolower($requestMethod));
+        $method = 'handle' . ucfirst(strtolower($requestMethod));
 
         return $this->{$method}();
     }
@@ -297,9 +297,9 @@ class Server extends AbstractTus
     protected function handleOptions() : HttpResponse
     {
         $headers = [
-            'Allow' => \implode(',', $this->request->allowedHttpVerbs()),
+            'Allow' => implode(',', $this->request->allowedHttpVerbs()),
             'Tus-Version' => self::TUS_PROTOCOL_VERSION,
-            'Tus-Extension' => \implode(',', self::TUS_EXTENSIONS),
+            'Tus-Extension' => implode(',', self::TUS_EXTENSIONS),
             'Tus-Checksum-Algorithm' => $this->getSupportedHashAlgorithms(),
         ];
 
@@ -400,7 +400,7 @@ class Server extends AbstractTus
         $partials  = $this->getRequest()->extractPartials();
         $uploadKey = $this->getUploadKey();
         $files     = $this->getPartialsMeta($partials);
-        $filePaths = \array_column($files, 'file_path');
+        $filePaths = array_column($files, 'file_path');
         $location  = $this->getRequest()->url() . $this->getApiPath() . '/' . $uploadKey;
 
         $file = $this->buildFile([
@@ -553,8 +553,8 @@ class Server extends AbstractTus
      */
     protected function handleDownload()
     {
-        $path = \explode('/', \str_replace('/get', '', $this->request->path()));
-        $key  = \end($path);
+        $path = explode('/', str_replace('/get', '', $this->request->path()));
+        $key  = end($path);
 
         if ( ! $fileMeta = $this->cache->get($key)) {
             return $this->response->send('404 upload not found.', HttpResponse::HTTP_NOT_FOUND);
@@ -563,7 +563,7 @@ class Server extends AbstractTus
         $resource = $fileMeta['file_path'] ?? null;
         $fileName = $fileMeta['name'] ?? null;
 
-        if ( ! $resource || ! \file_exists($resource)) {
+        if ( ! $resource || ! file_exists($resource)) {
             return $this->response->send('404 upload not found.', HttpResponse::HTTP_NOT_FOUND);
         }
 
@@ -587,7 +587,7 @@ class Server extends AbstractTus
 
         $isDeleted = $this->cache->delete($key);
 
-        if ( ! $isDeleted || ! \file_exists($resource)) {
+        if ( ! $isDeleted || ! file_exists($resource)) {
             return $this->response->send(null, HttpResponse::HTTP_GONE);
         }
 
@@ -653,14 +653,14 @@ class Server extends AbstractTus
 
         $algorithms = [];
         foreach ($supportedAlgorithms as $hashAlgo) {
-            if (false !== \strpos($hashAlgo, ',')) {
+            if (false !== strpos($hashAlgo, ',')) {
                 $algorithms[] = "'{$hashAlgo}'";
             } else {
                 $algorithms[] = $hashAlgo;
             }
         }
 
-        return \implode(',', $algorithms);
+        return implode(',', $algorithms);
     }
 
     /**
@@ -676,7 +676,7 @@ class Server extends AbstractTus
             return '';
         }
 
-        list($checksumAlgorithm, $checksum) = \explode(' ', $checksumHeader);
+        list($checksumAlgorithm, $checksum) = explode(' ', $checksumHeader);
 
         $checksum = base64_decode($checksum);
 
@@ -714,12 +714,12 @@ class Server extends AbstractTus
      */
     protected function getPathForPartialUpload(string $key) : string
     {
-        list($actualKey, /* $partialUploadKey */) = \explode(self::PARTIAL_UPLOAD_NAME_SEPARATOR, $key);
+        list($actualKey, /* $partialUploadKey */) = explode(self::PARTIAL_UPLOAD_NAME_SEPARATOR, $key);
 
         $path = $this->uploadDir . '/' . $actualKey . '/';
 
-        if ( ! \file_exists($path)) {
-            \mkdir($path);
+        if ( ! file_exists($path)) {
+            mkdir($path);
         }
 
         return $path;
@@ -766,7 +766,7 @@ class Server extends AbstractTus
                 continue;
             }
 
-            if (\is_writable($fileMeta['file_path'])) {
+            if (is_writable($fileMeta['file_path'])) {
                 unlink($fileMeta['file_path']);
             }
 

--- a/tests/FileTest.php
+++ b/tests/FileTest.php
@@ -666,7 +666,7 @@ class FileTest extends TestCase
         $file  = __DIR__ . '/.tmp/upload.txt';
         $data  = file_get_contents(__DIR__ . '/Fixtures/data.txt');
         $key   = uniqid();
-        $bytes = strlen($data);
+        $bytes = \strlen($data);
 
         $cacheMock = m::mock(FileStore::class);
         $fileMock  = m::mock(File::class, [null, $cacheMock])->makePartial();
@@ -779,7 +779,7 @@ class FileTest extends TestCase
         $data       = file_get_contents(__DIR__ . '/Fixtures/data.txt');
         $key        = uniqid();
         $checksum   = '74f02d6da32082463e382f2274e85fd8eae3e81f739f8959abc91865656e3b3a';
-        $totalBytes = strlen($data);
+        $totalBytes = \strlen($data);
 
         $cacheMock = m::mock(FileStore::class);
         $fileMock  = m::mock(File::class, [null, $cacheMock])->makePartial();

--- a/tests/Fixtures/config.php
+++ b/tests/Fixtures/config.php
@@ -15,7 +15,7 @@ return [
      * File cache configs.
      */
     'file' => [
-        'dir' => dirname(__DIR__) . DS . '.cache' . DS,
+        'dir' => \dirname(__DIR__) . DS . '.cache' . DS,
         'name' => 'tus_php.cache',
         'meta' => [
             'name' => 'test'

--- a/tests/Middleware/MiddlewareTest.php
+++ b/tests/Middleware/MiddlewareTest.php
@@ -52,7 +52,7 @@ class MiddlewareTest extends TestCase
     public function it_adds_valid_middleware()
     {
         $corsMock  = m::mock(Cors::class);
-        $mockClass = get_class($corsMock);
+        $mockClass = \get_class($corsMock);
 
         $this->assertInstanceOf(Middleware::class, $this->middleware->add($corsMock, TestMiddleware::class));
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -219,7 +219,7 @@ class RequestTest extends TestCase
         $this->assertEquals($filename, $this->request->extractFileName());
         $this->assertEquals($fileType, $this->request->extractMeta('type'));
         $this->assertEquals($accept, $this->request->extractMeta('accept'));
-        $this->assertEquals(['filename'=> $filename, 'type' => $fileType, 'accept' => $accept], $this->request->extractAllMeta());
+        $this->assertEquals(['filename' => $filename, 'type' => $fileType, 'accept' => $accept], $this->request->extractAllMeta());
     }
 
     /**
@@ -305,7 +305,7 @@ class RequestTest extends TestCase
         $uploadMetadata = array(
             'filename' => 'file.txt',
             'type' => 'image',
-            'accept'   => 'image/jpeg'
+            'accept' => 'image/jpeg'
         );
 
         $this->request

--- a/tests/Tus/ClientTest.php
+++ b/tests/Tus/ClientTest.php
@@ -800,7 +800,7 @@ class ClientTest extends TestCase
                 'body' => $data,
                 'headers' => [
                     'Content-Type' => 'application/offset+octet-stream',
-                    'Content-Length' => strlen($data),
+                    'Content-Length' => \strlen($data),
                     'Upload-Checksum' => $checksum,
                     'Upload-Offset' => $offset,
                 ],
@@ -869,7 +869,7 @@ class ClientTest extends TestCase
                 'body' => $data,
                 'headers' => [
                     'Content-Type' => 'application/offset+octet-stream',
-                    'Content-Length' => strlen($data),
+                    'Content-Length' => \strlen($data),
                     'Upload-Checksum' => $checksum,
                     'Upload-Offset' => $offset,
                 ],
@@ -938,7 +938,7 @@ class ClientTest extends TestCase
                 'body' => $data,
                 'headers' => [
                     'Content-Type' => 'application/offset+octet-stream',
-                    'Content-Length' => strlen($data),
+                    'Content-Length' => \strlen($data),
                     'Upload-Checksum' => $checksum,
                     'Upload-Offset' => $offset,
                 ],
@@ -1013,7 +1013,7 @@ class ClientTest extends TestCase
                 'body' => $data,
                 'headers' => [
                     'Content-Type' => 'application/offset+octet-stream',
-                    'Content-Length' => strlen($data),
+                    'Content-Length' => \strlen($data),
                     'Upload-Checksum' => $checksum,
                     'Upload-Offset' => $offset,
                 ],
@@ -1069,7 +1069,7 @@ class ClientTest extends TestCase
                 'body' => $data,
                 'headers' => [
                     'Content-Type' => 'application/offset+octet-stream',
-                    'Content-Length' => strlen($data),
+                    'Content-Length' => \strlen($data),
                     'Upload-Checksum' => $checksum,
                     'Upload-Offset' => $offset,
                 ],
@@ -1123,7 +1123,7 @@ class ClientTest extends TestCase
                 'body' => $data,
                 'headers' => [
                     'Content-Type' => 'application/offset+octet-stream',
-                    'Content-Length' => strlen($data),
+                    'Content-Length' => \strlen($data),
                     'Upload-Checksum' => $checksum,
                     'Upload-Offset' => $offset,
                 ],
@@ -1729,7 +1729,7 @@ class ClientTest extends TestCase
 
         $data = $this->tusClientMock->getData($offset, $dataLength);
 
-        $this->assertEquals($dataLength, strlen($data));
+        $this->assertEquals($dataLength, \strlen($data));
         $this->assertEquals(
             'The Project Gutenberg EBook of The Adventures of Sherlock Holmes by Sir Arthur Conan Doyle.',
             trim($data)
@@ -1754,7 +1754,7 @@ class ClientTest extends TestCase
 
         $data = $this->tusClientMock->getData($offset, $dataLength);
 
-        $this->assertEquals($dataLength, strlen($data));
+        $this->assertEquals($dataLength, \strlen($data));
         $this->assertEquals('Sherlock Holmes', $data);
     }
 

--- a/tests/Tus/ServerTest.php
+++ b/tests/Tus/ServerTest.php
@@ -91,11 +91,11 @@ class ServerTest extends TestCase
      */
     public function it_sets_and_gets_upload_dir()
     {
-        $this->assertEquals(dirname(__DIR__, 2) . '/uploads', $this->tusServer->getUploadDir());
+        $this->assertEquals(\dirname(__DIR__, 2) . '/uploads', $this->tusServer->getUploadDir());
 
-        $this->tusServer->setUploadDir(dirname(__DIR__) . '/storage');
+        $this->tusServer->setUploadDir(\dirname(__DIR__) . '/storage');
 
-        $this->assertEquals(dirname(__DIR__) . '/storage', $this->tusServer->getUploadDir());
+        $this->assertEquals(\dirname(__DIR__) . '/storage', $this->tusServer->getUploadDir());
     }
 
     /**
@@ -517,7 +517,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $this->tusServerMock->setCache($cacheMock);
@@ -559,7 +559,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $this->tusServerMock->setCache($cacheMock);
@@ -603,7 +603,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $this->tusServerMock->setCache($cacheMock);
@@ -651,7 +651,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $this->tusServerMock->setCache($cacheMock);
@@ -699,7 +699,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $this->tusServerMock->setCache($cacheMock);
@@ -918,7 +918,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $cacheMock
@@ -1036,7 +1036,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $cacheMock
@@ -1053,7 +1053,7 @@ class ServerTest extends TestCase
                 'offset' => 0,
                 'checksum' => $checksum,
                 'location' => $location,
-                'file_path' => dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'uploads' . DIRECTORY_SEPARATOR . $fileName,
+                'file_path' => \dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'uploads' . DIRECTORY_SEPARATOR . $fileName,
                 'metadata' => [
                     'filename' => $fileName,
                 ],
@@ -1148,7 +1148,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $cacheMock
@@ -1314,7 +1314,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $cacheMock
@@ -1412,7 +1412,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $this->tusServerMock->setCache($cacheMock);
@@ -1442,7 +1442,7 @@ class ServerTest extends TestCase
             'size' => $fileSize,
             'offset' => 0,
             'checksum' => $checksum,
-            'file_path' => dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName,
+            'file_path' => \dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName,
             'metadata' => [
                 'filename' => $fileName,
             ],
@@ -1477,7 +1477,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $this->tusServerMock->setCache($cacheMock);
@@ -1507,7 +1507,7 @@ class ServerTest extends TestCase
             'size' => $fileSize,
             'offset' => 0,
             'checksum' => $checksum,
-            'file_path' => dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName,
+            'file_path' => \dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName,
             'metadata' => [
                 'filename' => $fileName,
             ],
@@ -1580,7 +1580,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $this->tusServerMock->setCache($cacheMock);
@@ -1610,7 +1610,7 @@ class ServerTest extends TestCase
             'size' => $fileSize,
             'offset' => 0,
             'checksum' => $checksum,
-            'file_path' => dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName,
+            'file_path' => \dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName,
             'metadata' => [
                 'filename' => $fileName,
             ],
@@ -1683,7 +1683,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $this->tusServerMock->setCache($cacheMock);
@@ -1713,7 +1713,7 @@ class ServerTest extends TestCase
             'size' => $fileSize,
             'offset' => 0,
             'checksum' => $checksum,
-            'file_path' => dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName,
+            'file_path' => \dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName,
             'metadata' => [
                 'filename' => $fileName,
             ],
@@ -1786,7 +1786,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $this->tusServerMock->setCache($cacheMock);
@@ -1814,7 +1814,7 @@ class ServerTest extends TestCase
             'name' => $fileName,
             'size' => $fileSize,
             'offset' => 0,
-            'file_path' => dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName,
+            'file_path' => \dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName,
             'metadata' => [
                 'filename' => $fileName,
             ],
@@ -1843,7 +1843,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $this->tusServerMock->setCache($cacheMock);
@@ -1946,7 +1946,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $this->tusServerMock->setCache($cacheMock);
@@ -2066,7 +2066,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $this->tusServerMock->setCache($cacheMock);
@@ -2101,7 +2101,7 @@ class ServerTest extends TestCase
             'size' => $fileSize,
             'offset' => 0,
             'checksum' => $checksum,
-            'file_path' => dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName,
+            'file_path' => \dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName,
             'metadata' => [
                 'filename' => $fileName,
             ],
@@ -2185,7 +2185,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $this->tusServerMock->setCache($cacheMock);
@@ -2301,7 +2301,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $this->tusServerMock->setCache($cacheMock);
@@ -2341,7 +2341,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $this->tusServerMock->setCache($cacheMock);
@@ -2383,7 +2383,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $this->tusServerMock->setCache($cacheMock);
@@ -2439,7 +2439,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $this->tusServerMock->setCache($cacheMock);
@@ -2481,7 +2481,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $this->tusServerMock->setCache($cacheMock);
@@ -2522,7 +2522,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $cacheMock
@@ -2569,7 +2569,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $cacheMock
@@ -2646,7 +2646,7 @@ class ServerTest extends TestCase
     {
         $fileName  = 'file.txt';
         $fileSize  = 1024;
-        $filePath  = dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName;
+        $filePath  = \dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . $fileName;
         $location  = 'http://tus.local/uploads/file.txt';
         $createdAt = 'Fri, 08 Dec 2017 00:00:00 GMT';
         $expiresAt = 'Sat, 09 Dec 2017 00:00:00 GMT';
@@ -2931,7 +2931,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $cacheMock
@@ -2987,7 +2987,7 @@ class ServerTest extends TestCase
      */
     public function it_doesnt_unlink_if_unable_to_delete_from_cache()
     {
-        $filePath  = dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . 'empty.txt';
+        $filePath  = \dirname(__DIR__) . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . 'empty.txt';
         $cacheMock = m::mock(FileStore::class);
 
         $cacheMock
@@ -3009,7 +3009,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $cacheMock
@@ -3078,7 +3078,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $this->tusServerMock->setCache($cacheMock);
@@ -3156,7 +3156,7 @@ class ServerTest extends TestCase
             'size' => $fileSize,
             'offset' => 0,
             'checksum' => $checksum,
-            'file_path' => dirname(__DIR__) . DIRECTORY_SEPARATOR . $fileName,
+            'file_path' => \dirname(__DIR__) . DIRECTORY_SEPARATOR . $fileName,
             'metadata' => [
                 'filename' => $fileName,
             ],
@@ -3185,7 +3185,7 @@ class ServerTest extends TestCase
         $cacheMock
             ->shouldReceive('setPrefix')
             ->once()
-            ->with('tus:' . strtolower(get_class($this->tusServerMock)) . ':')
+            ->with('tus:' . strtolower(\get_class($this->tusServerMock)) . ':')
             ->andReturnSelf();
 
         $this->tusServerMock->setCache($cacheMock);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-define('DS', DIRECTORY_SEPARATOR);
+\define('DS', DIRECTORY_SEPARATOR);
 
 \Carbon\Carbon::setTestNow('2017-12-08');
 \TusPhp\Config::set(require __DIR__ . '/Fixtures/config.php');


### PR DESCRIPTION
This PR
- Adds PHP-CS-Fixer config `.php_cs` file.
- Reverts a part of #193 and
- Runs cs-fixer with `native_function_invocation` option in [`compiler_optimized` mode](https://github.com/php/php-src/blob/f2db305fa4e9bd7d04d567822687ec714aedcdb5/Zend/zend_compile.c#L3872).