### PR TITLE
Add psalm for static analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,16 @@ jobs:
 
       - name: Run friendsofphp/php-cs-fixer
         run: php7.3 ./vendor/bin/php-cs-fixer fix --diff-format=udiff --dry-run --show-progress=dots --using-cache=no --verbose
+
+  type-checker:
+    name: Type Checker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Update dependencies with composer
+        run: composer update --no-interaction --no-ansi --no-progress --no-suggest
+
+      - name: Run vimeo/psalm on internal code
+        run: php7.3 vendor/bin/psalm --config=.psalm/config.xml --no-progress --stats --show-info=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Update dependencies with composer
         run: composer update --no-interaction --no-ansi --no-progress --no-suggest
 
-      - name: Run vimeo/psalm on internal code
+      - name: Run vimeo/psalm
         run: php7.3 vendor/bin/psalm --config=.psalm/config.xml --no-progress --stats --show-info=false

--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="3.6.2@05ace258176795e87ef07b4262b5ceba3fd27de3">
+  <file src="src/Cache/FileStore.php">
+    <PossiblyInvalidArrayAccess occurrences="3">
+      <code>$contents[$key]</code>
+      <code>$contents[$cacheKey]</code>
+      <code>$this-&gt;getCacheContents()[$key]</code>
+    </PossiblyInvalidArrayAccess>
+  </file>
+  <file src="src/Commands/ExpirationCommand.php">
+    <InvalidOperand occurrences="1">
+      <code>$key</code>
+    </InvalidOperand>
+    <InvalidScalarArgument occurrences="1">
+      <code>$config</code>
+    </InvalidScalarArgument>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$cacheAdapter</code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="src/File.php">
+    <InvalidArgument occurrences="4">
+      <code>$output</code>
+      <code>$input</code>
+      <code>$output</code>
+      <code>$handle</code>
+    </InvalidArgument>
+    <PossiblyNullPropertyAssignmentValue occurrences="3">
+      <code>$name</code>
+      <code>$cache</code>
+      <code>$location</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <UndefinedDocblockClass occurrences="3">
+      <code>Resource</code>
+      <code>Resource</code>
+      <code>Resource</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="src/Middleware/Cors.php">
+    <InvalidReturnType occurrences="1">
+      <code>handle</code>
+    </InvalidReturnType>
+  </file>
+  <file src="src/Middleware/GlobalHeaders.php">
+    <InvalidReturnType occurrences="1">
+      <code>handle</code>
+    </InvalidReturnType>
+  </file>
+  <file src="src/Middleware/Middleware.php">
+    <InvalidArrayOffset occurrences="1">
+      <code>$this-&gt;globalMiddleware[$m]</code>
+    </InvalidArrayOffset>
+  </file>
+  <file src="src/Request.php">
+    <InvalidReturnStatement occurrences="1">
+      <code>$this-&gt;request-&gt;headers-&gt;get($key, $default)</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>string|null</code>
+    </InvalidReturnType>
+    <PossiblyInvalidArgument occurrences="3">
+      <code>$default</code>
+      <code>$uploadMetaData</code>
+      <code>$uploadMetaData</code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument occurrences="3">
+      <code>$meta</code>
+      <code>$meta</code>
+      <code>$this-&gt;header('Upload-Concat')</code>
+    </PossiblyNullArgument>
+    <TypeDoesNotContainType occurrences="1">
+      <code>explode(' ', $meta)</code>
+    </TypeDoesNotContainType>
+  </file>
+  <file src="src/Response.php">
+    <MismatchingDocblockParamType occurrences="1">
+      <code>string|null</code>
+    </MismatchingDocblockParamType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$disposition</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="src/Tus/Client.php">
+    <ImplicitToStringCast occurrences="2">
+      <code>$response-&gt;getBody()</code>
+      <code>$e-&gt;getResponse()-&gt;getBody()</code>
+    </ImplicitToStringCast>
+    <InvalidArgument occurrences="2">
+      <code>$handle</code>
+      <code>$handle</code>
+    </InvalidArgument>
+    <PossiblyNullArgument occurrences="5">
+      <code>$this-&gt;getFilePath()</code>
+      <code>$this-&gt;getUrl()</code>
+      <code>$this-&gt;getUrl()</code>
+      <code>$this-&gt;getUrl()</code>
+      <code>$this-&gt;getFilePath()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="3">
+      <code>getStatusCode</code>
+      <code>getStatusCode</code>
+      <code>getBody</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="src/Tus/Server.php">
+    <ImplicitToStringCast occurrences="7">
+      <code>$uploadKey</code>
+      <code>$uploadKey</code>
+      <code>$checksum</code>
+      <code>$uploadKey</code>
+      <code>$uploadKey</code>
+      <code>$uploadKey</code>
+      <code>$uploadKey</code>
+    </ImplicitToStringCast>
+    <InvalidArgument occurrences="4">
+      <code>UploadCreated::NAME</code>
+      <code>UploadMerged::NAME</code>
+      <code>UploadComplete::NAME</code>
+      <code>UploadProgress::NAME</code>
+    </InvalidArgument>
+    <PossiblyNullArgument occurrences="1">
+      <code>$this-&gt;getChecksumAlgorithm()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayAccess occurrences="2">
+      <code>$contents['offset']</code>
+      <code>$contents['size']</code>
+    </PossiblyNullArrayAccess>
+    <TooManyArguments occurrences="4">
+      <code>dispatch</code>
+      <code>dispatch</code>
+      <code>dispatch</code>
+      <code>dispatch</code>
+    </TooManyArguments>
+  </file>
+</files>

--- a/.psalm/config.xml
+++ b/.psalm/config.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="false"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline=".psalm/baseline.xml"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <LessSpecificReturnType errorLevel="info" />
+
+        <!-- level 3 issues - slightly lazy code writing, but provably low false-negatives -->
+
+        <DeprecatedMethod errorLevel="info" />
+        <DeprecatedProperty errorLevel="info" />
+        <DeprecatedClass errorLevel="info" />
+        <DeprecatedConstant errorLevel="info" />
+        <DeprecatedFunction errorLevel="info" />
+        <DeprecatedInterface errorLevel="info" />
+        <DeprecatedTrait errorLevel="info" />
+
+        <InternalMethod errorLevel="info" />
+        <InternalProperty errorLevel="info" />
+        <InternalClass errorLevel="info" />
+
+        <MissingClosureReturnType errorLevel="info" />
+        <MissingReturnType errorLevel="info" />
+        <MissingPropertyType errorLevel="info" />
+        <InvalidDocblock errorLevel="info" />
+        <MisplacedRequiredParam errorLevel="info" />
+
+        <PropertyNotSetInConstructor errorLevel="info" />
+        <MissingConstructor errorLevel="info" />
+        <MissingClosureParamType errorLevel="info" />
+        <MissingParamType errorLevel="info" />
+
+        <RedundantCondition errorLevel="info" />
+
+        <DocblockTypeContradiction errorLevel="info" />
+        <RedundantConditionGivenDocblockType errorLevel="info" />
+
+        <UnresolvableInclude errorLevel="info" />
+
+        <RawObjectIteration errorLevel="info" />
+
+        <InvalidStringClass errorLevel="info" />
+    </issueHandlers>
+</psalm>

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "friendsofphp/php-cs-fixer": "^2.9",
     "mockery/mockery": "^1.2.0",
     "php-mock/php-mock": "^2.0",
-    "phpunit/phpunit": "7.5.16"
+    "phpunit/phpunit": "7.5.16",
+    "vimeo/psalm": "^3.6"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Adds [psalm](https://github.com/vimeo/psalm) for static code analysis for finding errors.

`config.xml` generated from `psalm --init`
Left as default

`baseline.xml` generated from `vendor/bin/psalm --set-baseline=baseline.xml`
This file contains all the current errors which we can revisit later.