### PR TITLE
Update docker image to use php7.4 phpearth image

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -17,7 +17,6 @@ RUN set -x \
     && ln -sf /dev/stderr /var/log/nginx/error.log
 
 RUN apk update && apk add --no-cache \
-  php7.4-gd \
   php7.4-imap \
   php7.4-intl \
   php7.4-mbstring \

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM phpearth/php:7.2-nginx
+FROM phpearth/php:7.4-nginx
 
 LABEL maintainer="hello@ankit.pl,samundra@msn.com" \
   description="This builds tus-php-base image"
@@ -6,27 +6,35 @@ LABEL maintainer="hello@ankit.pl,samundra@msn.com" \
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
+ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub
+
 RUN ln -sf /usr/share/zoneinfo/Asia/Kathmandu /etc/localtime
+RUN set -x \
+    && echo "https://uk.alpinelinux.org/alpine/v3.9/community" >> /etc/apk/repositories \
+    && echo "https://uk.alpinelinux.org/alpine/v3.9/main" >> /etc/apk/repositories \
+    && apk add --no-cache $DEPS \
+    && ln -sf /dev/stdout /var/log/nginx/access.log \
+    && ln -sf /dev/stderr /var/log/nginx/error.log
 
-RUN apk add --no-cache \
-  php7.2-gd \
-  php7.2-imap \
-  php7.2-intl \
-  php7.2-mcrypt \
-  php7.2-mbstring \
-  php7.2-ldap \
-  php7.2-soap \
-  php7.2-curl
+RUN apk update && apk add --no-cache \
+  php7.4-gd \
+  php7.4-imap \
+  php7.4-intl \
+  php7.4-mbstring \
+  php7.4-openssl \
+  php7.4-ldap \
+  php7.4-soap \
+  php7.4-curl \
+  php7.4-pcntl \
+  composer
 
-## Composer installation
-RUN apk add --no-cache php7.2-pcntl composer
 
-## Xdebug Installation
-RUN apk add --no-cache php7.2-xdebug
+## Xdebug Installation, Currently Alpine repo is missing Php7.4-xdebug,
+# RUN apk add --no-cache php7.4-xdebug
 
 COPY ./configs/nginx.conf /etc/nginx/nginx.conf
 
-ENV PHP_INI_DIR /etc/php/7.2
+ENV PHP_INI_DIR /etc/php/7.4
 
 COPY ./configs/php.ini $PHP_INI_DIR/php.ini
 COPY ./configs/www.conf $PHP_INI_DIR/php-fpm.d/www.conf

--- a/docker/base/configs/www.conf
+++ b/docker/base/configs/www.conf
@@ -7,7 +7,7 @@ daemonize = yes
 [www]
 user = www-data
 group = www-data
-listen = /run/php-fpm7.2/php-fpm.sock
+listen = /run/php-fpm7.4/php-fpm.sock
 listen.owner = www-data
 listen.group = www-data
 pm = dynamic

--- a/docker/client/configs/default.conf
+++ b/docker/client/configs/default.conf
@@ -19,7 +19,7 @@ server {
     client_max_body_size 3000m;
 
     location ~ \.php$ {
-        fastcgi_pass unix:/run/php/php-fpm.sock;
+        fastcgi_pass unix:/run/php-fpm7.4/php-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_index index.php;
         include fastcgi_params;

--- a/docker/server/configs/default.conf
+++ b/docker/server/configs/default.conf
@@ -19,7 +19,7 @@ server {
     client_max_body_size 3000m;
 
     location ~ \.php$ {
-        fastcgi_pass unix:/run/php/php-fpm.sock;
+        fastcgi_pass unix:/run/php-fpm7.4/php-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_index index.php;
         include fastcgi_params;


### PR DESCRIPTION
✅ Update docker compose to use [phpearth docker/php7.4]

**Examples Tested**

✅ Test basic upload
✅ Test partial upload
✅ Test uppy client upload

**Change Log**
✅php-mcrypt has been replaced with php-openssl
- php-openssl which seems to work the same. `php-mcrypt` has been deprecated since  PHP7.2 so had to be replaced with alternative. Please look at this ticket for more insights into it.

**Current Limitation**

❌ php7.4-xdebug Php extension is missing on Alpine Ofice Repository. So, we either have to compile it manually or wait until it's available on Official Repository.

[phpearth docker/php7.4]: https://github.com/phpearth/docker-php/blob/master/docker/7.4-nginx.Dockerfile