### PR TITLE
ci: Enable APCu extension for PHP >= 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ env:
 
 before_install:
   - echo yes | pecl upgrade apcu
+  - |
+    if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.3" || ${TRAVIS_PHP_VERSION:0:3} == "7.4" ]]; then
+      echo "extension=apcu.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+    fi
   - echo "apc.enabled=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - echo "apc.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - composer self-update && composer update $FLAGS


### PR DESCRIPTION
[APCu](https://www.php.net/manual/en/book.apcu.php) extension in travis is not enabled after installation in PHP >= 7.3

**Before**
<img width="598" alt="Screenshot 2019-12-08 at 6 16 28 PM" src="https://user-images.githubusercontent.com/2364546/70393092-15acb000-19e7-11ea-809d-a1fbad9c1b45.png">

**After**
<img width="591" alt="Screenshot 2019-12-08 at 6 16 42 PM" src="https://user-images.githubusercontent.com/2364546/70393098-1e04eb00-19e7-11ea-9a7d-7d611e0fb286.png">
