### PR TITLE
Remove newline in bin/tus causing extra output

### DIFF
--- a/bin/tus
+++ b/bin/tus
@@ -1,5 +1,4 @@
 #!/usr/bin/env php
-
 <?php
 
 if (file_exists($autoloader = __DIR__ . '/../../../autoload.php')) {


### PR DESCRIPTION
This was causing additional output from commands even when passing the `--quiet` flag. Any output from commands used as a cronjob causes cron to notify the administrator via email.

To test, run `vendor/bin/tus tus:expired -q`. Before, it'd print an empty line. After, there is no output at all. (Alternatively, run `vendor/bin/tus` without any arguments to get the usage message, and notice the difference in newlines above the message.)