### PR TITLE
SF5 commands must return int

### DIFF
--- a/src/Commands/ExpirationCommand.php
+++ b/src/Commands/ExpirationCommand.php
@@ -70,5 +70,7 @@ class ExpirationCommand extends Command
         }
 
         $output->writeln('');
+        
+        return 0;
     }
 }


### PR DESCRIPTION
From SF5 [upgrade.md](https://github.com/symfony/symfony/blob/master/UPGRADE-5.0.md):
`Removed support for returning null from Command::execute(), return 0 instead`

Error with current code:
```
PHP Fatal error:  Uncaught TypeError: Return value of "TusPhp\Commands\ExpirationCommand::execute()" must be of the type int, NULL returned. in /srv/api/vendor/symfony/console/Command/Command.php:258
Stack trace:
#0 /srv/api/vendor/symfony/console/Application.php(925): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#1 /srv/api/vendor/symfony/console/Application.php(265): Symfony\Component\Console\Application->doRunCommand(Object(TusPhp\Commands\ExpirationCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#2 /srv/api/vendor/symfony/console/Application.php(141): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#3 /srv/api/vendor/ankitpokhrel/tus-php/bin/tus(18): Symfony\Component\Console\Application->run()
#4 {main}
  thrown in /srv/api/vendor/symfony/console/Command/Command.php on line 258

Fatal error: Uncaught TypeError: Return value of "TusPhp\Commands\ExpirationCommand::execute()" must be of the type int, NULL returned. in /srv/api/vendor/symfony/console/Command/Command.php on line 258

TypeError: Return value of "TusPhp\Commands\ExpirationCommand::execute()" must be of the type int, NULL returned. in /srv/api/vendor/symfony/console/Command/Command.php on line 258
```