### PR TITLE
Support for Symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
     "nesbot/carbon": "^1.26.3 || ^2.0",
     "predis/predis": "^1.1",
     "ramsey/uuid": "^3.7",
-    "symfony/console": "^3.4 || ^4.0",
-    "symfony/event-dispatcher": "^3.4 || ^4.0",
-    "symfony/http-foundation": "^3.4 || ^4.2"
+    "symfony/console": "^3.4 || ^4.0 || ^5.0",
+    "symfony/event-dispatcher": "^3.4 || ^4.0 || ^5.0",
+    "symfony/http-foundation": "^3.4 || ^4.2 || ^5.0"
   },
   "require-dev": {
     "ext-pcntl": "*",


### PR DESCRIPTION
This allows use of the new Symfony 5 version to avoid incompatibilities with downstream packages.