### PR TITLE
dep: symfony/mime is now explicitly required to guess the mime type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "ramsey/uuid": "^3.7 || ^4.0",
     "symfony/console": "^5.0",
     "symfony/event-dispatcher": "^5.0",
-    "symfony/http-foundation": "^5.0.7"
+    "symfony/http-foundation": "^5.0.7",
+    "symfony/mime": "^5.1"
   },
   "require-dev": {
     "ext-pcntl": "*",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "symfony/console": "^5.0",
     "symfony/event-dispatcher": "^5.0",
     "symfony/http-foundation": "^5.0.7",
-    "symfony/mime": "^5.1"
+    "symfony/mime": "^5.0.9"
   },
   "require-dev": {
     "ext-pcntl": "*",


### PR DESCRIPTION
See https://github.com/symfony/http-foundation/commit/63f42630839c6e2b097ae4a183ca9d3992ccd80a