### PR TITLE
Response::create is deprecated since Symfony 5.1

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -19,14 +19,6 @@ class Response
     protected $headers = [];
 
     /**
-     * Response constructor.
-     */
-    public function __construct()
-    {
-        $this->response = new HttpResponse;
-    }
-
-    /**
      * Set create only.
      *
      * @param bool $state
@@ -105,7 +97,7 @@ class Response
             $content = json_encode($content);
         }
 
-        $response = $this->response::create($content, $status, $headers);
+        $response = new HttpResponse($content, $status, $headers);
 
         return $this->createOnly ? $response : $response->send();
     }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -28,7 +28,6 @@ class ResponseTest extends TestCase
     /**
      * @test
      *
-     * @covers ::__construct
      * @covers ::createOnly
      * @covers ::getCreateOnly
      */
@@ -44,7 +43,6 @@ class ResponseTest extends TestCase
     /**
      * @test
      *
-     * @covers ::__construct
      * @covers ::setHeaders
      * @covers ::getHeaders
      */


### PR DESCRIPTION
Fixes #274 