### PR TITLE
Fix namespace declaration

### DIFF
--- a/tests/Tus/ClientTest.php
+++ b/tests/Tus/ClientTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TusPhp\Test;
+namespace TusPhp\Test\Tus;
 
 use Mockery as m;
 use GuzzleHttp\Client;

--- a/tests/Tus/ServerTest.php
+++ b/tests/Tus/ServerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TusPhp\Test;
+namespace TusPhp\Test\Tus;
 
 use TusPhp\File;
 use Mockery as m;


### PR DESCRIPTION
This commit fixes Composer autoloader deprecation notices:

Deprecation Notice: Class TusPhp\Test\ServerTest located in
./tests/Tus/ServerTest.php does not comply with psr-4
autoloading standard.