### PR TITLE
ci: Downgrade dev php version to 7.3

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM phpearth/php:7.4-nginx
+FROM phpearth/php:7.3-nginx
 
 LABEL maintainer="hello@ankit.pl,samundra@msn.com" \
   description="This builds tus-php-base image"
@@ -9,23 +9,17 @@ ENV LC_ALL C.UTF-8
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub
 
 RUN ln -sf /usr/share/zoneinfo/Asia/Kathmandu /etc/localtime
-RUN set -x \
-    && echo "https://uk.alpinelinux.org/alpine/v3.9/community" >> /etc/apk/repositories \
-    && echo "https://uk.alpinelinux.org/alpine/v3.9/main" >> /etc/apk/repositories \
-    && apk add --no-cache $DEPS \
-    && ln -sf /dev/stdout /var/log/nginx/access.log \
-    && ln -sf /dev/stderr /var/log/nginx/error.log
 
 RUN apk update && apk add --no-cache \
-  php7.4-imap \
-  php7.4-intl \
-  php7.4-mbstring \
-  php7.4-openssl \
-  php7.4-ldap \
-  php7.4-curl \
-  php7.4-pcntl \
-  php7.4-dev \
-  php7.4-pear \
+  php7.3-imap \
+  php7.3-intl \
+  php7.3-mbstring \
+  php7.3-openssl \
+  php7.3-ldap \
+  php7.3-curl \
+  php7.3-pcntl \
+  php7.3-dev \
+  php7.3-pear \
   composer
 
 # Install APCu extension
@@ -36,7 +30,7 @@ RUN pecl upgrade apcu
 
 COPY ./configs/nginx.conf /etc/nginx/nginx.conf
 
-ENV PHP_INI_DIR /etc/php/7.4
+ENV PHP_INI_DIR /etc/php/7.3
 
 COPY ./configs/php.ini $PHP_INI_DIR/php.ini
 COPY ./configs/www.conf $PHP_INI_DIR/php-fpm.d/www.conf

--- a/docker/base/configs/www.conf
+++ b/docker/base/configs/www.conf
@@ -7,7 +7,7 @@ daemonize = yes
 [www]
 user = www-data
 group = www-data
-listen = /run/php-fpm7.4/php-fpm.sock
+listen = /run/php-fpm7.3/php-fpm.sock
 listen.owner = www-data
 listen.group = www-data
 pm = dynamic

--- a/docker/client/configs/default.conf
+++ b/docker/client/configs/default.conf
@@ -19,7 +19,7 @@ server {
     client_max_body_size 3000m;
 
     location ~ \.php$ {
-        fastcgi_pass unix:/run/php-fpm7.4/php-fpm.sock;
+        fastcgi_pass unix:/run/php-fpm7.3/php-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_index index.php;
         include fastcgi_params;

--- a/docker/server/configs/default.conf
+++ b/docker/server/configs/default.conf
@@ -19,7 +19,7 @@ server {
     client_max_body_size 3000m;
 
     location ~ \.php$ {
-        fastcgi_pass unix:/run/php-fpm7.4/php-fpm.sock;
+        fastcgi_pass unix:/run/php-fpm7.3/php-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_index index.php;
         include fastcgi_params;


### PR DESCRIPTION
Since [phpearth/docker-php](https://github.com/phpearth/docker-php) is still using `PHP7.4.0-alpha1`, we are reverting back to 7.3 until we find better alternative.