### PR TITLE
Call assertions statically

### DIFF
--- a/tests/Cache/ApcuStoreTest.php
+++ b/tests/Cache/ApcuStoreTest.php
@@ -41,7 +41,7 @@ class ApcuStoreTest extends TestCase
     protected function setUp() : void
     {
         if ( ! self::$extensionLoaded) {
-            $this->markTestSkipped('APCU extension not loaded.');
+            self::markTestSkipped('APCU extension not loaded.');
         }
 
         parent::setUp();
@@ -55,9 +55,9 @@ class ApcuStoreTest extends TestCase
      */
     public function it_sets_and_gets_apcu_cache_prefix() : void
     {
-        $this->assertEquals('tus:', static::$store->getPrefix());
-        $this->assertInstanceOf(ApcuStore::class, static::$store->setPrefix('apcu:'));
-        $this->assertEquals('apcu:', static::$store->getPrefix());
+        self::assertEquals('tus:', static::$store->getPrefix());
+        self::assertInstanceOf(ApcuStore::class, static::$store->setPrefix('apcu:'));
+        self::assertEquals('apcu:', static::$store->getPrefix());
     }
 
     /**
@@ -75,19 +75,19 @@ class ApcuStoreTest extends TestCase
 
         static::$store->setTtl(1);
 
-        $this->assertTrue(static::$store->set($this->checksum, $cacheContent));
-        $this->assertEquals($cacheContent, static::$store->get($this->checksum));
+        self::assertTrue(static::$store->set($this->checksum, $cacheContent));
+        self::assertEquals($cacheContent, static::$store->get($this->checksum));
 
         $string   = 'Sherlock Holmes';
         $checksum = '74f02d6da32082463e382f22';
 
-        $this->assertTrue(static::$store->set($checksum, $cacheContent));
+        self::assertTrue(static::$store->set($checksum, $cacheContent));
 
         $cacheContent[] = $string;
 
-        $this->assertTrue(static::$store->set($checksum, $string));
-        $this->assertEquals($cacheContent, static::$store->get($checksum));
-        $this->assertTrue(static::$store->delete($checksum));
+        self::assertTrue(static::$store->set($checksum, $string));
+        self::assertEquals($cacheContent, static::$store->get($checksum));
+        self::assertTrue(static::$store->delete($checksum));
     }
 
     /**
@@ -101,12 +101,12 @@ class ApcuStoreTest extends TestCase
      */
     public function it_doesnt_replace_cache_key_in_set() : void
     {
-        $this->assertTrue(static::$store->set($this->checksum, ['offset' => 500]));
+        self::assertTrue(static::$store->set($this->checksum, ['offset' => 500]));
 
         $contents = static::$store->get($this->checksum);
 
-        $this->assertEquals(500, $contents['offset']);
-        $this->assertEquals('Sat, 09 Dec 2017 16:25:51 GMT', $contents['expires_at']);
+        self::assertEquals(500, $contents['offset']);
+        self::assertEquals('Sat, 09 Dec 2017 16:25:51 GMT', $contents['expires_at']);
     }
 
     /**
@@ -119,7 +119,7 @@ class ApcuStoreTest extends TestCase
     {
         $cacheContent = ['expires_at' => 'Sat, 09 Dec 2017 16:25:51 GMT', 'offset' => 500];
 
-        $this->assertEquals($cacheContent, static::$store->get($this->checksum));
+        self::assertEquals($cacheContent, static::$store->get($this->checksum));
     }
 
     /**
@@ -132,8 +132,8 @@ class ApcuStoreTest extends TestCase
     {
         $cacheContent = ['expires_at' => 'Thu, 07 Dec 2017 16:25:51 GMT', 'offset' => 100];
 
-        $this->assertTrue(static::$store->set($this->checksum, $cacheContent));
-        $this->assertNull(static::$store->get($this->checksum));
+        self::assertTrue(static::$store->set($this->checksum, $cacheContent));
+        self::assertNull(static::$store->get($this->checksum));
     }
 
     /**
@@ -146,9 +146,9 @@ class ApcuStoreTest extends TestCase
     {
         $cacheContent = ['expires_at' => 'Thu, 07 Dec 2017 16:25:51 GMT', 'offset' => 100];
 
-        $this->assertTrue(static::$store->set($this->checksum, $cacheContent));
-        $this->assertNull(static::$store->get($this->checksum));
-        $this->assertEquals($cacheContent, static::$store->get($this->checksum, true));
+        self::assertTrue(static::$store->set($this->checksum, $cacheContent));
+        self::assertNull(static::$store->get($this->checksum));
+        self::assertEquals($cacheContent, static::$store->get($this->checksum, true));
     }
 
     /**
@@ -163,11 +163,11 @@ class ApcuStoreTest extends TestCase
     {
         $cacheContent = ['expires_at' => 'Fri, 08 Dec 2017 16:25:51 GMT', 'offset' => 100];
 
-        $this->assertTrue(static::$store->set($this->checksum, $cacheContent));
-        $this->assertEquals($cacheContent, static::$store->get($this->checksum));
-        $this->assertFalse(static::$store->delete('invalid-checksum'));
-        $this->assertTrue(static::$store->delete($this->checksum));
-        $this->assertNull(static::$store->get($this->checksum));
+        self::assertTrue(static::$store->set($this->checksum, $cacheContent));
+        self::assertEquals($cacheContent, static::$store->get($this->checksum));
+        self::assertFalse(static::$store->delete('invalid-checksum'));
+        self::assertTrue(static::$store->delete($this->checksum));
+        self::assertNull(static::$store->get($this->checksum));
     }
 
     /**
@@ -184,12 +184,12 @@ class ApcuStoreTest extends TestCase
         $checksum2    = 'checksum-2';
         $cacheContent = ['expires_at' => 'Fri, 08 Dec 2017 16:25:51 GMT', 'offset' => 100];
 
-        $this->assertTrue(static::$store->set($checksum1, $cacheContent));
-        $this->assertTrue(static::$store->set($checksum2, $cacheContent));
-        $this->assertTrue(static::$store->deleteAll([$checksum1, $checksum2]));
-        $this->assertFalse(static::$store->deleteAll([]));
-        $this->assertNull(static::$store->get($checksum1));
-        $this->assertNull(static::$store->get($checksum2));
+        self::assertTrue(static::$store->set($checksum1, $cacheContent));
+        self::assertTrue(static::$store->set($checksum2, $cacheContent));
+        self::assertTrue(static::$store->deleteAll([$checksum1, $checksum2]));
+        self::assertFalse(static::$store->deleteAll([]));
+        self::assertNull(static::$store->get($checksum1));
+        self::assertNull(static::$store->get($checksum2));
     }
 
     /**
@@ -199,7 +199,7 @@ class ApcuStoreTest extends TestCase
      */
     public function it_gets_cache_keys() : void
     {
-        $this->assertTrue(static::$store->set($this->checksum, []));
-        $this->assertEquals([static::$store->getPrefix() . $this->checksum], static::$store->keys());
+        self::assertTrue(static::$store->set($this->checksum, []));
+        self::assertEquals([static::$store->getPrefix() . $this->checksum], static::$store->keys());
     }
 }

--- a/tests/Cache/CacheFactoryTest.php
+++ b/tests/Cache/CacheFactoryTest.php
@@ -20,9 +20,9 @@ class CacheFactoryTest extends TestCase
      */
     public function it_makes_cache_store_object() : void
     {
-        $this->assertInstanceOf(FileStore::class, CacheFactory::make());
-        $this->assertInstanceOf(RedisStore::class, CacheFactory::make('redis'));
-        $this->assertInstanceOf(ApcuStore::class, CacheFactory::make('apcu'));
-        $this->assertInstanceOf(FileStore::class, CacheFactory::make('invalid'));
+        self::assertInstanceOf(FileStore::class, CacheFactory::make());
+        self::assertInstanceOf(RedisStore::class, CacheFactory::make('redis'));
+        self::assertInstanceOf(ApcuStore::class, CacheFactory::make('apcu'));
+        self::assertInstanceOf(FileStore::class, CacheFactory::make('invalid'));
     }
 }

--- a/tests/Cache/FileStoreTest.php
+++ b/tests/Cache/FileStoreTest.php
@@ -50,11 +50,11 @@ class FileStoreTest extends TestCase
      */
     public function it_sets_and_gets_ttl() : void
     {
-        $this->assertEquals(86400, $this->fileStore->getTtl());
+        self::assertEquals(86400, $this->fileStore->getTtl());
 
         $this->fileStore->setTtl(10);
 
-        $this->assertEquals(10, $this->fileStore->getTtl());
+        self::assertEquals(10, $this->fileStore->getTtl());
     }
 
     /**
@@ -65,9 +65,9 @@ class FileStoreTest extends TestCase
      */
     public function it_sets_and_gets_file_cache_prefix() : void
     {
-        $this->assertEquals('tus:', $this->fileStore->getPrefix());
-        $this->assertInstanceOf(FileStore::class, $this->fileStore->setPrefix('file:'));
-        $this->assertEquals('file:', $this->fileStore->getPrefix());
+        self::assertEquals('tus:', $this->fileStore->getPrefix());
+        self::assertInstanceOf(FileStore::class, $this->fileStore->setPrefix('file:'));
+        self::assertEquals('file:', $this->fileStore->getPrefix());
     }
 
     /**
@@ -78,7 +78,7 @@ class FileStoreTest extends TestCase
      */
     public function it_sets_default_cache_dir_and_file() : void
     {
-        $this->assertEquals(Config::get('file.dir') . Config::get('file.name'), (new FileStore)->getCacheFile());
+        self::assertEquals(Config::get('file.dir') . Config::get('file.name'), (new FileStore)->getCacheFile());
     }
 
     /**
@@ -95,8 +95,8 @@ class FileStoreTest extends TestCase
         $fileCache = new FileStore($cacheDir);
         $fileStore = new FileStore($cacheDir, $cacheFile);
 
-        $this->assertEquals($cacheDir . 'tus_php.cache', $fileCache->getCacheFile());
-        $this->assertEquals($cacheDir . $cacheFile, $fileStore->getCacheFile());
+        self::assertEquals($cacheDir . 'tus_php.cache', $fileCache->getCacheFile());
+        self::assertEquals($cacheDir . $cacheFile, $fileStore->getCacheFile());
     }
 
     /**
@@ -109,8 +109,8 @@ class FileStoreTest extends TestCase
     {
         $cacheDir = '/path/to/cache/dir';
 
-        $this->assertInstanceOf(FileStore::class, $this->fileStore->setCacheDir($cacheDir));
-        $this->assertEquals($cacheDir, $this->fileStore->getCacheDir());
+        self::assertInstanceOf(FileStore::class, $this->fileStore->setCacheDir($cacheDir));
+        self::assertEquals($cacheDir, $this->fileStore->getCacheDir());
     }
 
     /**
@@ -126,8 +126,8 @@ class FileStoreTest extends TestCase
 
         $fileStore = new FileStore;
 
-        $this->assertInstanceOf(FileStore::class, $fileStore->setCacheFile($cacheFile));
-        $this->assertEquals($defaultCacheDir . $cacheFile, $fileStore->getCacheFile());
+        self::assertInstanceOf(FileStore::class, $fileStore->setCacheFile($cacheFile));
+        self::assertEquals($defaultCacheDir . $cacheFile, $fileStore->getCacheFile());
     }
 
     /**
@@ -142,11 +142,11 @@ class FileStoreTest extends TestCase
     {
         $this->fileStore->set($this->checksum, 'Test');
 
-        $this->assertFileExists($this->cacheDir);
-        $this->assertFileExists($this->cacheDir.$this->cacheFile);
+        self::assertFileExists($this->cacheDir);
+        self::assertFileExists($this->cacheDir.$this->cacheFile);
 
         // Cache is invalid, should return null.
-        $this->assertEquals(null, $this->fileStore->get($this->checksum));
+        self::assertEquals(null, $this->fileStore->get($this->checksum));
     }
 
     /**
@@ -166,9 +166,9 @@ class FileStoreTest extends TestCase
 
         $this->fileStore->set($this->checksum, $cacheContent);
 
-        $this->assertFileExists($this->cacheDir);
-        $this->assertFileExists($this->cacheDir.$this->cacheFile);
-        $this->assertEquals($cacheContent, $this->fileStore->get($this->checksum));
+        self::assertFileExists($this->cacheDir);
+        self::assertFileExists($this->cacheDir.$this->cacheFile);
+        self::assertEquals($cacheContent, $this->fileStore->get($this->checksum));
     }
 
     /**
@@ -184,14 +184,14 @@ class FileStoreTest extends TestCase
 
         $this->fileStore->set($this->checksum, $cacheContent);
 
-        $this->assertEquals($cacheContent, $this->fileStore->get($this->checksum));
+        self::assertEquals($cacheContent, $this->fileStore->get($this->checksum));
 
         $this->fileStore->set($this->checksum, ['offset' => 500]);
 
         $contents = $this->fileStore->get($this->checksum);
 
-        $this->assertEquals(500, $contents['offset']);
-        $this->assertEquals('Sat, 09 Dec 2017 16:25:51 GMT', $contents['expires_at']);
+        self::assertEquals(500, $contents['offset']);
+        self::assertEquals('Sat, 09 Dec 2017 16:25:51 GMT', $contents['expires_at']);
     }
 
     /**
@@ -203,7 +203,7 @@ class FileStoreTest extends TestCase
     {
         $content = $this->fileStore->get($this->checksum);
 
-        $this->assertNull($content);
+        self::assertNull($content);
     }
 
     /**
@@ -218,12 +218,12 @@ class FileStoreTest extends TestCase
 
         $this->fileStore->set($this->checksum, $cacheContent);
 
-        $this->assertNull($this->fileStore->get($this->checksum));
+        self::assertNull($this->fileStore->get($this->checksum));
 
         $cacheContent = ['expires_at' => 'Thu, 07 Dec 2017 16:25:51 GMT'];
         $this->fileStore->set($this->checksum, $cacheContent);
 
-        $this->assertNull($this->fileStore->get($this->checksum));
+        self::assertNull($this->fileStore->get($this->checksum));
     }
 
     /**
@@ -237,8 +237,8 @@ class FileStoreTest extends TestCase
 
         $this->fileStore->set($this->checksum, $cacheContent);
 
-        $this->assertNull($this->fileStore->get($this->checksum));
-        $this->assertEquals($cacheContent, $this->fileStore->get($this->checksum, true));
+        self::assertNull($this->fileStore->get($this->checksum));
+        self::assertEquals($cacheContent, $this->fileStore->get($this->checksum, true));
     }
 
     /**
@@ -253,7 +253,7 @@ class FileStoreTest extends TestCase
 
         $this->fileStore->set($this->checksum, $cacheContent);
 
-        $this->assertEquals($cacheContent, $this->fileStore->get($this->checksum));
+        self::assertEquals($cacheContent, $this->fileStore->get($this->checksum));
     }
 
     /**
@@ -268,12 +268,12 @@ class FileStoreTest extends TestCase
 
         $this->fileStore->set($this->checksum, $cacheContent);
 
-        $this->assertTrue($this->fileStore->isValid($this->checksum));
+        self::assertTrue($this->fileStore->isValid($this->checksum));
 
         $cacheContent = ['expires_at' => 'Thu, 07 Dec 2017 16:25:51 GMT'];
         $this->fileStore->set($this->checksum, $cacheContent);
 
-        $this->assertFalse($this->fileStore->isValid($this->checksum));
+        self::assertFalse($this->fileStore->isValid($this->checksum));
     }
 
     /**
@@ -283,7 +283,7 @@ class FileStoreTest extends TestCase
      */
     public function it_returns_false_if_cache_file_doesnt_exist() : void
     {
-        $this->assertFalse($this->fileStore->getCacheContents());
+        self::assertFalse($this->fileStore->getCacheContents());
     }
 
     /**
@@ -306,7 +306,7 @@ class FileStoreTest extends TestCase
 
         $this->fileStore->set($checksum, $content);
 
-        $this->assertEquals($expected, $this->fileStore->getCacheContents());
+        self::assertEquals($expected, $this->fileStore->getCacheContents());
     }
 
     /**
@@ -324,11 +324,11 @@ class FileStoreTest extends TestCase
 
         $this->fileStore->set($this->checksum, $cacheContent);
 
-        $this->assertEquals(['tus:' . $this->checksum => $cacheContent], $this->fileStore->getCacheContents());
+        self::assertEquals(['tus:' . $this->checksum => $cacheContent], $this->fileStore->getCacheContents());
 
-        $this->assertFalse($this->fileStore->delete('invalid-checksum'));
-        $this->assertTrue($this->fileStore->delete($this->checksum));
-        $this->assertNull($this->fileStore->get($this->checksum));
+        self::assertFalse($this->fileStore->delete('invalid-checksum'));
+        self::assertTrue($this->fileStore->delete($this->checksum));
+        self::assertNull($this->fileStore->get($this->checksum));
     }
 
     /**
@@ -347,10 +347,10 @@ class FileStoreTest extends TestCase
         $this->fileStore->set($checksum1, $cacheContent);
         $this->fileStore->set($checksum2, $cacheContent);
 
-        $this->assertTrue($this->fileStore->deleteAll([$checksum1, $checksum2]));
-        $this->assertFalse($this->fileStore->deleteAll([]));
-        $this->assertNull($this->fileStore->get($checksum1));
-        $this->assertNull($this->fileStore->get($checksum2));
+        self::assertTrue($this->fileStore->deleteAll([$checksum1, $checksum2]));
+        self::assertFalse($this->fileStore->deleteAll([]));
+        self::assertNull($this->fileStore->get($checksum1));
+        self::assertNull($this->fileStore->get($checksum2));
     }
 
     /**
@@ -362,7 +362,7 @@ class FileStoreTest extends TestCase
     {
         $this->fileStore->set($this->checksum, []);
 
-        $this->assertEquals(['tus:' . $this->checksum], $this->fileStore->keys());
+        self::assertEquals(['tus:' . $this->checksum], $this->fileStore->keys());
     }
 
     /**
@@ -374,7 +374,7 @@ class FileStoreTest extends TestCase
     {
         $this->fileStore->setCacheFile('/path/to/invalid/file');
 
-        $this->assertEquals([], $this->fileStore->keys());
+        self::assertEquals([], $this->fileStore->keys());
     }
 
     /**
@@ -385,13 +385,13 @@ class FileStoreTest extends TestCase
      */
     public function it_gets_actual_cache_key() : void
     {
-        $this->assertEquals('tus:cache-key', $this->fileStore->getActualCacheKey('cache-key'));
-        $this->assertEquals('tus:cache-key', $this->fileStore->getActualCacheKey('tus:cache-key'));
+        self::assertEquals('tus:cache-key', $this->fileStore->getActualCacheKey('cache-key'));
+        self::assertEquals('tus:cache-key', $this->fileStore->getActualCacheKey('tus:cache-key'));
 
-        $this->assertInstanceOf(FileStore::class, $this->fileStore->setPrefix('hello:'));
+        self::assertInstanceOf(FileStore::class, $this->fileStore->setPrefix('hello:'));
 
-        $this->assertEquals('hello:cache-key', $this->fileStore->getActualCacheKey('cache-key'));
-        $this->assertEquals('hello:cache-key', $this->fileStore->getActualCacheKey('hello:cache-key'));
+        self::assertEquals('hello:cache-key', $this->fileStore->getActualCacheKey('cache-key'));
+        self::assertEquals('hello:cache-key', $this->fileStore->getActualCacheKey('hello:cache-key'));
     }
 
     /**
@@ -427,7 +427,7 @@ class FileStoreTest extends TestCase
         while (-1 !== pcntl_waitpid(0, $status)) {
             $status = pcntl_wexitstatus($status);
 
-            $this->assertSame($status, 0);
+            self::assertSame($status, 0);
         }
 
         @unlink($filePath);
@@ -440,7 +440,7 @@ class FileStoreTest extends TestCase
      */
     public function it_gets_empty_contents_for_invalid_file_in_shared_get() : void
     {
-        $this->assertEmpty($this->fileStore->sharedGet(__DIR__ . '/.tmp/invalid.file'));
+        self::assertEmpty($this->fileStore->sharedGet(__DIR__ . '/.tmp/invalid.file'));
     }
 
     /**

--- a/tests/Cache/RedisStoreTest.php
+++ b/tests/Cache/RedisStoreTest.php
@@ -55,7 +55,7 @@ class RedisStoreTest extends TestCase
     protected function setUp() : void
     {
         if (false === static::$redisStore) {
-            $this->markTestSkipped('Unable to connect to redis.');
+            self::markTestSkipped('Unable to connect to redis.');
         }
 
         $this->checksum = '74f02d6da32082463e382f2274e85fd8eae3e81f739f8959abc91865656e3b3a';
@@ -82,7 +82,7 @@ class RedisStoreTest extends TestCase
         try {
             $redisStore->getRedis()->ping();
         } catch (Exception $e) {
-            $this->assertInstanceOf(ConnectionException::class, $e);
+            self::assertInstanceOf(ConnectionException::class, $e);
         }
     }
 
@@ -94,9 +94,9 @@ class RedisStoreTest extends TestCase
      */
     public function it_sets_and_gets_redis_cache_prefix() : void
     {
-        $this->assertEquals('tus:', static::$redisStore->getPrefix());
-        $this->assertInstanceOf(RedisStore::class, static::$redisStore->setPrefix('redis:'));
-        $this->assertEquals('redis:', static::$redisStore->getPrefix());
+        self::assertEquals('tus:', static::$redisStore->getPrefix());
+        self::assertInstanceOf(RedisStore::class, static::$redisStore->setPrefix('redis:'));
+        self::assertEquals('redis:', static::$redisStore->getPrefix());
     }
 
     /**
@@ -111,23 +111,23 @@ class RedisStoreTest extends TestCase
     {
         $cacheContent = ['expires_at' => 'Sat, 09 Dec 2017 16:25:51 GMT', 'offset' => 100];
 
-        $this->assertNull(static::$redisStore->get('invalid key'));
+        self::assertNull(static::$redisStore->get('invalid key'));
 
         static::$redisStore->setTtl(1);
 
-        $this->assertTrue(static::$redisStore->set($this->checksum, $cacheContent));
-        $this->assertEquals($cacheContent, static::$redisStore->get($this->checksum));
+        self::assertTrue(static::$redisStore->set($this->checksum, $cacheContent));
+        self::assertEquals($cacheContent, static::$redisStore->get($this->checksum));
 
         $string   = 'Sherlock Holmes';
         $checksum = '74f02d6da32082463e382f22';
 
-        $this->assertTrue(static::$redisStore->set($checksum, $cacheContent));
+        self::assertTrue(static::$redisStore->set($checksum, $cacheContent));
 
         $cacheContent[] = $string;
 
-        $this->assertTrue(static::$redisStore->set($checksum, $string));
-        $this->assertEquals($cacheContent, static::$redisStore->get($checksum));
-        $this->assertTrue(static::$redisStore->delete($checksum));
+        self::assertTrue(static::$redisStore->set($checksum, $string));
+        self::assertEquals($cacheContent, static::$redisStore->get($checksum));
+        self::assertTrue(static::$redisStore->delete($checksum));
     }
 
     /**
@@ -140,12 +140,12 @@ class RedisStoreTest extends TestCase
      */
     public function it_doesnt_replace_cache_key_in_set() : void
     {
-        $this->assertTrue(static::$redisStore->set($this->checksum, ['offset' => 500]));
+        self::assertTrue(static::$redisStore->set($this->checksum, ['offset' => 500]));
 
         $contents = static::$redisStore->get($this->checksum);
 
-        $this->assertEquals(500, $contents['offset']);
-        $this->assertEquals('Sat, 09 Dec 2017 16:25:51 GMT', $contents['expires_at']);
+        self::assertEquals(500, $contents['offset']);
+        self::assertEquals('Sat, 09 Dec 2017 16:25:51 GMT', $contents['expires_at']);
     }
 
     /**
@@ -157,7 +157,7 @@ class RedisStoreTest extends TestCase
     {
         $cacheContent = ['expires_at' => 'Sat, 09 Dec 2017 16:25:51 GMT', 'offset' => 500];
 
-        $this->assertEquals($cacheContent, static::$redisStore->get($this->checksum));
+        self::assertEquals($cacheContent, static::$redisStore->get($this->checksum));
     }
 
     /**
@@ -169,8 +169,8 @@ class RedisStoreTest extends TestCase
     {
         $cacheContent = ['expires_at' => 'Thu, 07 Dec 2017 16:25:51 GMT', 'offset' => 100];
 
-        $this->assertTrue(static::$redisStore->set($this->checksum, $cacheContent));
-        $this->assertNull(static::$redisStore->get($this->checksum));
+        self::assertTrue(static::$redisStore->set($this->checksum, $cacheContent));
+        self::assertNull(static::$redisStore->get($this->checksum));
     }
 
     /**
@@ -182,9 +182,9 @@ class RedisStoreTest extends TestCase
     {
         $cacheContent = ['expires_at' => 'Thu, 07 Dec 2017 16:25:51 GMT', 'offset' => 100];
 
-        $this->assertTrue(static::$redisStore->set($this->checksum, $cacheContent));
-        $this->assertNull(static::$redisStore->get($this->checksum));
-        $this->assertEquals($cacheContent, static::$redisStore->get($this->checksum, true));
+        self::assertTrue(static::$redisStore->set($this->checksum, $cacheContent));
+        self::assertNull(static::$redisStore->get($this->checksum));
+        self::assertEquals($cacheContent, static::$redisStore->get($this->checksum, true));
     }
 
     /**
@@ -198,11 +198,11 @@ class RedisStoreTest extends TestCase
     {
         $cacheContent = ['expires_at' => 'Fri, 08 Dec 2017 16:25:51 GMT', 'offset' => 100];
 
-        $this->assertTrue(static::$redisStore->set($this->checksum, $cacheContent));
-        $this->assertEquals($cacheContent, static::$redisStore->get($this->checksum));
-        $this->assertFalse(static::$redisStore->delete('invalid-checksum'));
-        $this->assertTrue(static::$redisStore->delete($this->checksum));
-        $this->assertNull(static::$redisStore->get($this->checksum));
+        self::assertTrue(static::$redisStore->set($this->checksum, $cacheContent));
+        self::assertEquals($cacheContent, static::$redisStore->get($this->checksum));
+        self::assertFalse(static::$redisStore->delete('invalid-checksum'));
+        self::assertTrue(static::$redisStore->delete($this->checksum));
+        self::assertNull(static::$redisStore->get($this->checksum));
     }
 
     /**
@@ -218,12 +218,12 @@ class RedisStoreTest extends TestCase
         $checksum2    = 'checksum-2';
         $cacheContent = ['expires_at' => 'Fri, 08 Dec 2017 16:25:51 GMT', 'offset' => 100];
 
-        $this->assertTrue(static::$redisStore->set($checksum1, $cacheContent));
-        $this->assertTrue(static::$redisStore->set($checksum2, $cacheContent));
-        $this->assertTrue(static::$redisStore->deleteAll([$checksum1, $checksum2]));
-        $this->assertFalse(static::$redisStore->deleteAll([]));
-        $this->assertNull(static::$redisStore->get($checksum1));
-        $this->assertNull(static::$redisStore->get($checksum2));
+        self::assertTrue(static::$redisStore->set($checksum1, $cacheContent));
+        self::assertTrue(static::$redisStore->set($checksum2, $cacheContent));
+        self::assertTrue(static::$redisStore->deleteAll([$checksum1, $checksum2]));
+        self::assertFalse(static::$redisStore->deleteAll([]));
+        self::assertNull(static::$redisStore->get($checksum1));
+        self::assertNull(static::$redisStore->get($checksum2));
     }
 
     /**
@@ -233,7 +233,7 @@ class RedisStoreTest extends TestCase
      */
     public function it_gets_redis_object() : void
     {
-        $this->assertInstanceOf(Client::class, static::$redisStore->getRedis());
+        self::assertInstanceOf(Client::class, static::$redisStore->getRedis());
     }
 
     /**
@@ -243,8 +243,8 @@ class RedisStoreTest extends TestCase
      */
     public function it_gets_cache_keys() : void
     {
-        $this->assertTrue(static::$redisStore->set($this->checksum, []));
-        $this->assertEquals([static::$redisStore->getPrefix() . $this->checksum], static::$redisStore->keys());
+        self::assertTrue(static::$redisStore->set($this->checksum, []));
+        self::assertEquals([static::$redisStore->getPrefix() . $this->checksum], static::$redisStore->keys());
     }
 
     /**

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -47,7 +47,7 @@ class ConfigTest extends TestCase
 
         Config::set($config, true);
 
-        $this->assertEquals($config, Config::get());
+        self::assertEquals($config, Config::get());
     }
 
     /**
@@ -60,7 +60,7 @@ class ConfigTest extends TestCase
     {
         Config::set(__DIR__ . '/Fixtures/config.php', true);
 
-        $this->assertEquals($this->config, Config::get());
+        self::assertEquals($this->config, Config::get());
     }
 
     /**
@@ -73,8 +73,8 @@ class ConfigTest extends TestCase
     {
         Config::set([]);
 
-        $this->assertNotEmpty(Config::get());
-        $this->assertEquals($this->config, Config::get());
+        self::assertNotEmpty(Config::get());
+        self::assertEquals($this->config, Config::get());
     }
 
     /**
@@ -84,9 +84,9 @@ class ConfigTest extends TestCase
      */
     public function it_gets_value_for_a_key() : void
     {
-        $this->assertEquals($this->config['redis'], Config::get('redis'));
-        $this->assertEquals($this->config['redis']['host'], Config::get('redis.host'));
-        $this->assertEquals($this->config['file']['meta']['name'], Config::get('file.meta.name'));
+        self::assertEquals($this->config['redis'], Config::get('redis'));
+        self::assertEquals($this->config['redis']['host'], Config::get('redis.host'));
+        self::assertEquals($this->config['file']['meta']['name'], Config::get('file.meta.name'));
     }
 
     /**
@@ -96,6 +96,6 @@ class ConfigTest extends TestCase
      */
     public function it_returns_null_for_invalid_key() : void
     {
-        $this->assertNull(Config::get('redis.invalid'));
+        self::assertNull(Config::get('redis.invalid'));
     }
 }

--- a/tests/FileTest.php
+++ b/tests/FileTest.php
@@ -52,13 +52,13 @@ class FileTest extends TestCase
 
         $meta = $this->file->details();
 
-        $this->assertEquals('tus.txt', $meta['name']);
-        $this->assertEquals(2056, $meta['size']);
-        $this->assertEquals(200, $meta['offset']);
-        $this->assertEquals('http://tus.local/uploads/file.pdf', $meta['location']);
-        $this->assertEquals('/path/to/file.pdf', $meta['file_path']);
-        $this->assertEquals('Fri, 08 Dec 2017 00:00:00 GMT', $meta['created_at']);
-        $this->assertEquals('Sat, 09 Dec 2017 00:00:00 GMT', $meta['expires_at']);
+        self::assertEquals('tus.txt', $meta['name']);
+        self::assertEquals(2056, $meta['size']);
+        self::assertEquals(200, $meta['offset']);
+        self::assertEquals('http://tus.local/uploads/file.pdf', $meta['location']);
+        self::assertEquals('/path/to/file.pdf', $meta['file_path']);
+        self::assertEquals('Fri, 08 Dec 2017 00:00:00 GMT', $meta['created_at']);
+        self::assertEquals('Sat, 09 Dec 2017 00:00:00 GMT', $meta['expires_at']);
     }
 
     /**
@@ -69,10 +69,10 @@ class FileTest extends TestCase
      */
     public function it_sets_and_gets_name() : void
     {
-        $this->assertEquals('tus.txt', $this->file->getName());
+        self::assertEquals('tus.txt', $this->file->getName());
 
-        $this->assertInstanceOf(File::class, $this->file->setName('file.txt'));
-        $this->assertEquals('file.txt', $this->file->getName());
+        self::assertInstanceOf(File::class, $this->file->setName('file.txt'));
+        self::assertEquals('file.txt', $this->file->getName());
     }
 
     /**
@@ -83,10 +83,10 @@ class FileTest extends TestCase
      */
     public function it_sets_and_gets_file_size() : void
     {
-        $this->assertEquals(1024, $this->file->getFileSize());
+        self::assertEquals(1024, $this->file->getFileSize());
 
-        $this->assertInstanceOf(File::class, $this->file->setFileSize(2056));
-        $this->assertEquals(2056, $this->file->getFileSize());
+        self::assertInstanceOf(File::class, $this->file->setFileSize(2056));
+        self::assertEquals(2056, $this->file->getFileSize());
     }
 
     /**
@@ -99,8 +99,8 @@ class FileTest extends TestCase
     {
         $checksum = '74f02d6da32082463e382f2274e85fd8eae3e81f739f8959abc91865656e3b3a';
 
-        $this->assertInstanceOf(File::class, $this->file->setChecksum($checksum));
-        $this->assertEquals($checksum, $this->file->getChecksum());
+        self::assertInstanceOf(File::class, $this->file->setChecksum($checksum));
+        self::assertEquals($checksum, $this->file->getChecksum());
     }
 
     /**
@@ -113,8 +113,8 @@ class FileTest extends TestCase
     {
         $key = uniqid();
 
-        $this->assertInstanceOf(File::class, $this->file->setKey($key));
-        $this->assertEquals($key, $this->file->getKey());
+        self::assertInstanceOf(File::class, $this->file->setKey($key));
+        self::assertEquals($key, $this->file->getKey());
     }
 
     /**
@@ -125,9 +125,9 @@ class FileTest extends TestCase
      */
     public function it_sets_and_gets_offset() : void
     {
-        $this->assertEquals(100, $this->file->getOffset());
-        $this->assertInstanceOf(File::class, $this->file->setOffset(500));
-        $this->assertEquals(500, $this->file->getOffset());
+        self::assertEquals(100, $this->file->getOffset());
+        self::assertInstanceOf(File::class, $this->file->setOffset(500));
+        self::assertEquals(500, $this->file->getOffset());
     }
 
     /**
@@ -138,12 +138,12 @@ class FileTest extends TestCase
      */
     public function it_sets_and_gets_location() : void
     {
-        $this->assertEquals('http://tus.local/uploads/file.txt', $this->file->getLocation());
+        self::assertEquals('http://tus.local/uploads/file.txt', $this->file->getLocation());
 
         $location = 'http://tus.local/uploads/file.pdf';
 
-        $this->assertInstanceOf(File::class, $this->file->setLocation($location));
-        $this->assertEquals($location, $this->file->getLocation());
+        self::assertInstanceOf(File::class, $this->file->setLocation($location));
+        self::assertEquals($location, $this->file->getLocation());
     }
 
     /**
@@ -154,12 +154,12 @@ class FileTest extends TestCase
      */
     public function it_sets_and_gets_file_path() : void
     {
-        $this->assertEquals('/path/to/file.txt', $this->file->getFilePath());
+        self::assertEquals('/path/to/file.txt', $this->file->getFilePath());
 
         $filePath = '/path/to/file.pdf';
 
-        $this->assertInstanceOf(File::class, $this->file->setFilePath($filePath));
-        $this->assertEquals($filePath, $this->file->getFilePath());
+        self::assertInstanceOf(File::class, $this->file->setFilePath($filePath));
+        self::assertEquals($filePath, $this->file->getFilePath());
     }
 
     /**
@@ -169,7 +169,7 @@ class FileTest extends TestCase
      */
     public function it_gets_input_stream() : void
     {
-        $this->assertEquals('php://input', $this->file->getInputStream());
+        self::assertEquals('php://input', $this->file->getInputStream());
     }
 
     /**
@@ -185,7 +185,7 @@ class FileTest extends TestCase
             'filePath' => '/path/to/file.pdf',
         ];
 
-        $this->assertInstanceOf(File::class, $this->file->setUploadMetadata($metadata));
+        self::assertInstanceOf(File::class, $this->file->setUploadMetadata($metadata));
     }
 
     /**
@@ -233,7 +233,7 @@ class FileTest extends TestCase
 
         $resource = $this->file->open($file, 'rb');
 
-        $this->assertIsResource($resource);
+        self::assertIsResource($resource);
 
         $this->file->close($resource);
     }
@@ -245,9 +245,9 @@ class FileTest extends TestCase
      */
     public function it_checks_if_file_exists_based_on_mode() : void
     {
-        $this->assertTrue($this->file->exists('php://input'));
-        $this->assertTrue($this->file->exists(__DIR__ . '/Fixtures/empty.txt'));
-        $this->assertTrue($this->file->exists(__DIR__ . '/Fixtures/invalid.txt', 'wb+'));
+        self::assertTrue($this->file->exists('php://input'));
+        self::assertTrue($this->file->exists(__DIR__ . '/Fixtures/empty.txt'));
+        self::assertTrue($this->file->exists(__DIR__ . '/Fixtures/invalid.txt', 'wb+'));
     }
 
     /**
@@ -260,7 +260,7 @@ class FileTest extends TestCase
         $this->expectException(FileException::class);
         $this->expectExceptionMessage('File not found.');
 
-        $this->assertFalse($this->file->exists(__DIR__ . '/Fixtures/invalid.txt'));
+        self::assertFalse($this->file->exists(__DIR__ . '/Fixtures/invalid.txt'));
     }
 
     /**
@@ -310,7 +310,7 @@ class FileTest extends TestCase
 
         $this->file->seek($handle, 5);
 
-        $this->assertEquals(5, ftell($handle));
+        self::assertEquals(5, ftell($handle));
 
         $this->file->close($handle);
     }
@@ -363,7 +363,7 @@ class FileTest extends TestCase
 
         $this->file->seek($handle, 49);
 
-        $this->assertEquals('Sherlock Holmes', $this->file->read($handle, 15));
+        self::assertEquals('Sherlock Holmes', $this->file->read($handle, 15));
 
         $this->file->close($handle);
     }
@@ -417,11 +417,11 @@ class FileTest extends TestCase
 
         $this->file->write($handle, 'Sherlock Holmes', $bytes);
 
-        $this->assertEquals('', $this->file->read($handle, $bytes));
+        self::assertEquals('', $this->file->read($handle, $bytes));
 
         $this->file->seek($handle, 0);
 
-        $this->assertEquals('Sherlock Holmes', $this->file->read($handle, $bytes));
+        self::assertEquals('Sherlock Holmes', $this->file->read($handle, $bytes));
 
         $this->file->close($handle);
 
@@ -473,10 +473,10 @@ class FileTest extends TestCase
 
         $this->file->setFilePath($mergedFilePath)->merge($files);
 
-        $this->assertFileExists($mergedFilePath);
-        $this->assertEquals('123', file_get_contents($mergedFilePath));
-        $this->assertEquals(60, $this->file->getOffset());
-        $this->assertEquals(3, $this->file->getFileSize());
+        self::assertFileExists($mergedFilePath);
+        self::assertEquals('123', file_get_contents($mergedFilePath));
+        self::assertEquals(60, $this->file->getOffset());
+        self::assertEquals(3, $this->file->getFileSize());
 
         @unlink($mergedFilePath);
 
@@ -500,7 +500,7 @@ class FileTest extends TestCase
 
         $this->file->delete($files, true);
 
-        $this->assertFileNotExists($path);
+        self::assertFileNotExists($path);
     }
 
     /**
@@ -547,11 +547,11 @@ class FileTest extends TestCase
         $this->file->delete($files);
 
         foreach ($files as $file) {
-            $this->assertFileNotExists($file);
+            self::assertFileNotExists($file);
         }
 
-        $this->assertFileExists($path);
-        $this->assertDirectoryExists($path);
+        self::assertFileExists($path);
+        self::assertDirectoryExists($path);
 
         return $path;
     }
@@ -568,7 +568,7 @@ class FileTest extends TestCase
     {
         $this->file->delete([], true);
 
-        $this->assertFileExists($path);
+        self::assertFileExists($path);
     }
 
     /**
@@ -583,7 +583,7 @@ class FileTest extends TestCase
     {
         $this->file->delete(["$path/1"], true);
 
-        $this->assertFileNotExists($path);
+        self::assertFileNotExists($path);
     }
 
     /**
@@ -593,7 +593,7 @@ class FileTest extends TestCase
      */
     public function it_throws_file_exception_if_already_uploaded() : void
     {
-        $this->assertEquals(1000, $this->file->setOffset(1000)->upload(1000));
+        self::assertEquals(1000, $this->file->setOffset(1000)->upload(1000));
     }
 
     /**
@@ -762,7 +762,7 @@ class FileTest extends TestCase
             ->setOffset(0)
             ->upload($totalBytes);
 
-        $this->assertEquals($totalBytes, $bytesWritten);
+        self::assertEquals($totalBytes, $bytesWritten);
 
         $mock->disable();
 
@@ -820,7 +820,7 @@ class FileTest extends TestCase
             ->setOffset(0)
             ->upload($totalBytes);
 
-        $this->assertEquals($totalBytes, $bytesWritten);
+        self::assertEquals($totalBytes, $bytesWritten);
 
         $mock->disable();
 

--- a/tests/Middleware/CorsTest.php
+++ b/tests/Middleware/CorsTest.php
@@ -50,7 +50,7 @@ class CorsTest extends TestCase
             ])
             ->andReturnSelf();
 
-        $this->assertNull($this->cors->handle($requestMock, $responseMock));
+        self::assertNull($this->cors->handle($requestMock, $responseMock));
     }
 
     /**

--- a/tests/Middleware/GlobalHeadersTest.php
+++ b/tests/Middleware/GlobalHeadersTest.php
@@ -47,7 +47,7 @@ class GlobalHeadersTest extends TestCase
             ])
             ->andReturnSelf();
 
-        $this->assertNull($this->globalHeaders->handle($requestMock, $responseMock));
+        self::assertNull($this->globalHeaders->handle($requestMock, $responseMock));
     }
 
     /**

--- a/tests/Middleware/MiddlewareTest.php
+++ b/tests/Middleware/MiddlewareTest.php
@@ -39,8 +39,8 @@ class MiddlewareTest extends TestCase
     {
         $middleware = $this->middleware->list();
 
-        $this->assertInstanceOf(GlobalHeaders::class, $middleware[GlobalHeaders::class]);
-        $this->assertInstanceOf(Cors::class, $middleware[Cors::class]);
+        self::assertInstanceOf(GlobalHeaders::class, $middleware[GlobalHeaders::class]);
+        self::assertInstanceOf(Cors::class, $middleware[Cors::class]);
     }
 
     /**
@@ -54,15 +54,15 @@ class MiddlewareTest extends TestCase
         $corsMock  = m::mock(Cors::class);
         $mockClass = \get_class($corsMock);
 
-        $this->assertInstanceOf(Middleware::class, $this->middleware->add($corsMock, TestMiddleware::class));
+        self::assertInstanceOf(Middleware::class, $this->middleware->add($corsMock, TestMiddleware::class));
 
         $middleware = $this->middleware->list();
 
-        $this->assertCount(4, $middleware);
-        $this->assertInstanceOf($mockClass, $middleware[$mockClass]);
-        $this->assertInstanceOf(Cors::class, $middleware[Cors::class]);
-        $this->assertInstanceOf(GlobalHeaders::class, $middleware[GlobalHeaders::class]);
-        $this->assertInstanceOf(TestMiddleware::class, $middleware[TestMiddleware::class]);
+        self::assertCount(4, $middleware);
+        self::assertInstanceOf($mockClass, $middleware[$mockClass]);
+        self::assertInstanceOf(Cors::class, $middleware[Cors::class]);
+        self::assertInstanceOf(GlobalHeaders::class, $middleware[GlobalHeaders::class]);
+        self::assertInstanceOf(TestMiddleware::class, $middleware[TestMiddleware::class]);
     }
 
     /**
@@ -72,7 +72,7 @@ class MiddlewareTest extends TestCase
      */
     public function it_gets_middleware_list() : void
     {
-        $this->assertCount(2, $this->middleware->list());
+        self::assertCount(2, $this->middleware->list());
     }
 
     /**
@@ -83,12 +83,12 @@ class MiddlewareTest extends TestCase
      */
     public function it_skips_given_middleware() : void
     {
-        $this->assertInstanceOf(Middleware::class, $this->middleware->skip(GlobalHeaders::class));
+        self::assertInstanceOf(Middleware::class, $this->middleware->skip(GlobalHeaders::class));
 
         $middleware = $this->middleware->list();
 
-        $this->assertCount(1, $middleware);
-        $this->assertInstanceOf(Cors::class, $middleware[Cors::class]);
+        self::assertCount(1, $middleware);
+        self::assertInstanceOf(Cors::class, $middleware[Cors::class]);
     }
 
     /**

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -34,13 +34,13 @@ class RequestTest extends TestCase
      */
     public function it_returns_current_request_method() : void
     {
-        $this->assertEquals('GET', $this->request->method());
+        self::assertEquals('GET', $this->request->method());
 
         $request = new Request;
 
         $request->getRequest()->server->set('REQUEST_METHOD', 'POST');
 
-        $this->assertEquals('POST', $request->method());
+        self::assertEquals('POST', $request->method());
     }
 
     /**
@@ -54,7 +54,7 @@ class RequestTest extends TestCase
 
         $this->request->getRequest()->server->set('REQUEST_URI', '/files/' . $checksum);
 
-        $this->assertEquals($checksum, $this->request->key());
+        self::assertEquals($checksum, $this->request->key());
     }
 
     /**
@@ -66,7 +66,7 @@ class RequestTest extends TestCase
     {
         $this->request->getRequest()->server->set('REQUEST_URI', '/tus/files/');
 
-        $this->assertEquals('/tus/files/', $this->request->path());
+        self::assertEquals('/tus/files/', $this->request->path());
     }
 
     /**
@@ -76,7 +76,7 @@ class RequestTest extends TestCase
      */
     public function it_returns_allowed_http_verbs() : void
     {
-        $this->assertEquals([
+        self::assertEquals([
             'GET',
             'POST',
             'PATCH',
@@ -95,7 +95,7 @@ class RequestTest extends TestCase
     {
         $this->request->getRequest()->headers->set('content-length', 100);
 
-        $this->assertEquals(100, $this->request->header('content-length'));
+        self::assertEquals(100, $this->request->header('content-length'));
     }
 
     /**
@@ -110,14 +110,14 @@ class RequestTest extends TestCase
             'SERVER_PORT' => 80,
         ]);
 
-        $this->assertEquals('http://tus.local', $this->request->url());
+        self::assertEquals('http://tus.local', $this->request->url());
 
         $this->request->getRequest()->server->add([
             'REQUEST_URI' => '/tus/files/',
             'QUERY_STRING' => 'token=random&path=root',
         ]);
 
-        $this->assertEquals('http://tus.local', $this->request->url());
+        self::assertEquals('http://tus.local', $this->request->url());
     }
 
     /**
@@ -130,9 +130,9 @@ class RequestTest extends TestCase
         $this->request->getRequest()->headers->set('Upload-Metadata', 'filename dGVzdA==');
         $this->request->getRequest()->headers->set('Upload-Concat', 'final;/files/a /files/b');
 
-        $this->assertEquals([], $this->request->extractFromHeader('Upload-Metadata', 'invalid'));
-        $this->assertEquals(['dGVzdA=='], $this->request->extractFromHeader('Upload-Metadata', 'filename'));
-        $this->assertEquals(['/files/a', '/files/b'], $this->request->extractFromHeader('Upload-Concat', 'final;'));
+        self::assertEquals([], $this->request->extractFromHeader('Upload-Metadata', 'invalid'));
+        self::assertEquals(['dGVzdA=='], $this->request->extractFromHeader('Upload-Metadata', 'filename'));
+        self::assertEquals(['/files/a', '/files/b'], $this->request->extractFromHeader('Upload-Concat', 'final;'));
     }
 
     /**
@@ -160,7 +160,7 @@ class RequestTest extends TestCase
 
         foreach ($validFileNames as $filename) {
             $this->request->getRequest()->headers->set('Upload-Metadata', 'name ' . base64_encode($filename));
-            $this->assertEquals($filename, $this->request->extractFileName());
+            self::assertEquals($filename, $this->request->extractFileName());
         }
     }
 
@@ -186,7 +186,7 @@ class RequestTest extends TestCase
 
         foreach ($badFileNames as $filename) {
             $this->request->getRequest()->headers->set('Upload-Metadata', 'name ' . base64_encode($filename));
-            $this->assertEquals('', $this->request->extractFileName());
+            self::assertEquals('', $this->request->extractFileName());
         }
     }
 
@@ -216,10 +216,10 @@ class RequestTest extends TestCase
                 )
             );
 
-        $this->assertEquals($filename, $this->request->extractFileName());
-        $this->assertEquals($fileType, $this->request->extractMeta('type'));
-        $this->assertEquals($accept, $this->request->extractMeta('accept'));
-        $this->assertEquals(['filename' => $filename, 'type' => $fileType, 'accept' => $accept], $this->request->extractAllMeta());
+        self::assertEquals($filename, $this->request->extractFileName());
+        self::assertEquals($fileType, $this->request->extractMeta('type'));
+        self::assertEquals($accept, $this->request->extractMeta('accept'));
+        self::assertEquals(['filename' => $filename, 'type' => $fileType, 'accept' => $accept], $this->request->extractAllMeta());
     }
 
     /**
@@ -230,15 +230,15 @@ class RequestTest extends TestCase
      */
     public function it_returns_empty_if_upload_metadata_header_not_present() : void
     {
-        $this->assertEmpty($this->request->extractMeta('invalid-key'));
+        self::assertEmpty($this->request->extractMeta('invalid-key'));
 
         $this->request
             ->getRequest()
             ->headers
             ->set('Upload-Metadata', '');
 
-        $this->assertEmpty($this->request->extractMeta('invalid-key'));
-        $this->assertEmpty($this->request->extractAllMeta());
+        self::assertEmpty($this->request->extractMeta('invalid-key'));
+        self::assertEmpty($this->request->extractAllMeta());
     }
 
     /**
@@ -251,7 +251,7 @@ class RequestTest extends TestCase
     {
         $this->request->getRequest()->headers->set('Upload-Concat', 'final;/files/a /files/b');
 
-        $this->assertEquals(['/files/a', '/files/b'], $this->request->extractPartials());
+        self::assertEquals(['/files/a', '/files/b'], $this->request->extractPartials());
     }
 
     /**
@@ -261,11 +261,11 @@ class RequestTest extends TestCase
      */
     public function it_checks_if_a_request_is_partial() : void
     {
-        $this->assertFalse($this->request->isPartial());
+        self::assertFalse($this->request->isPartial());
 
         $this->request->getRequest()->headers->set('Upload-Concat', 'partial');
 
-        $this->assertTrue($this->request->isPartial());
+        self::assertTrue($this->request->isPartial());
     }
 
     /**
@@ -275,11 +275,11 @@ class RequestTest extends TestCase
      */
     public function it_checks_if_a_request_is_final() : void
     {
-        $this->assertFalse($this->request->isFinal());
+        self::assertFalse($this->request->isFinal());
 
         $this->request->getRequest()->headers->set('Upload-Concat', 'final;/files/a /files/b');
 
-        $this->assertTrue($this->request->isFinal());
+        self::assertTrue($this->request->isFinal());
     }
 
     /**
@@ -289,7 +289,7 @@ class RequestTest extends TestCase
      */
     public function it_gets_request() : void
     {
-        $this->assertInstanceOf(HttpRequest::class, $this->request->getRequest());
+        self::assertInstanceOf(HttpRequest::class, $this->request->getRequest());
     }
 
     /**
@@ -300,7 +300,7 @@ class RequestTest extends TestCase
     public function it_extracts_all_metadata() : void
     {
         $this->request->getRequest()->headers->set('Upload-Metadata', '');
-        $this->assertEmpty($this->request->extractAllMeta());
+        self::assertEmpty($this->request->extractAllMeta());
 
         $uploadMetadata = array(
             'filename' => 'file.txt',
@@ -322,6 +322,6 @@ class RequestTest extends TestCase
                 true
             );
 
-        $this->assertEquals($uploadMetadata, $this->request->extractAllMeta());
+        self::assertEquals($uploadMetadata, $this->request->extractAllMeta());
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -34,11 +34,11 @@ class ResponseTest extends TestCase
      */
     public function it_sets_and_gets_create_only() : void
     {
-        $this->assertTrue($this->response->getCreateOnly());
+        self::assertTrue($this->response->getCreateOnly());
 
         $this->response->createOnly(false);
 
-        $this->assertFalse($this->response->getCreateOnly());
+        self::assertFalse($this->response->getCreateOnly());
     }
 
     /**
@@ -49,19 +49,19 @@ class ResponseTest extends TestCase
      */
     public function it_sets_and_gets_headers() : void
     {
-        $this->assertEquals([], $this->response->getHeaders());
+        self::assertEquals([], $this->response->getHeaders());
 
         $headers = [
             'Access-Control-Allow-Origin' => '*',
             'Access-Control-Max-Age' => 86400,
         ];
 
-        $this->assertInstanceOf(Response::class, $this->response->setHeaders($headers));
-        $this->assertInstanceOf(
+        self::assertInstanceOf(Response::class, $this->response->setHeaders($headers));
+        self::assertInstanceOf(
             Response::class,
             $this->response->setHeaders(['Access-Control-Allow-Methods' => 'GET,POST'])
         );
-        $this->assertEquals($headers + ['Access-Control-Allow-Methods' => 'GET,POST'], $this->response->getHeaders());
+        self::assertEquals($headers + ['Access-Control-Allow-Methods' => 'GET,POST'], $this->response->getHeaders());
     }
 
     /**
@@ -73,13 +73,13 @@ class ResponseTest extends TestCase
      */
     public function it_replaces_headers() : void
     {
-        $this->assertEquals([], $this->response->getHeaders());
-        $this->assertInstanceOf(Response::class, $this->response->setHeaders(['Access-Control-Max-Age' => 86400]));
-        $this->assertInstanceOf(
+        self::assertEquals([], $this->response->getHeaders());
+        self::assertInstanceOf(Response::class, $this->response->setHeaders(['Access-Control-Max-Age' => 86400]));
+        self::assertInstanceOf(
             Response::class,
             $this->response->replaceHeaders(['Access-Control-Allow-Methods' => 'GET,POST'])
         );
-        $this->assertEquals(['Access-Control-Allow-Methods' => 'GET,POST'], $this->response->getHeaders());
+        self::assertEquals(['Access-Control-Allow-Methods' => 'GET,POST'], $this->response->getHeaders());
     }
 
     /**
@@ -95,10 +95,10 @@ class ResponseTest extends TestCase
             ->setHeaders(['Access-Control-Max-Age' => 86400])
             ->send($content, 204, ['Offset' => 100]);
 
-        $this->assertEquals(204, $response->getStatusCode());
-        $this->assertEquals($content, $response->getContent());
-        $this->assertEquals(86400, $response->headers->get('Access-Control-Max-Age'));
-        $this->assertEquals(100, $response->headers->get('Offset'));
+        self::assertEquals(204, $response->getStatusCode());
+        self::assertEquals($content, $response->getContent());
+        self::assertEquals(86400, $response->headers->get('Access-Control-Max-Age'));
+        self::assertEquals(100, $response->headers->get('Offset'));
     }
 
     /**
@@ -113,9 +113,9 @@ class ResponseTest extends TestCase
             ->createOnly(true)
             ->send($content, 204, ['Offset' => 100]);
 
-        $this->assertEquals(204, $response->getStatusCode());
-        $this->assertEquals(json_encode($content), $response->getContent());
-        $this->assertEquals(100, $response->headers->get('Offset'));
+        self::assertEquals(204, $response->getStatusCode());
+        self::assertEquals(json_encode($content), $response->getContent());
+        self::assertEquals(100, $response->headers->get('Offset'));
     }
 
     /**
@@ -143,8 +143,8 @@ class ResponseTest extends TestCase
 
         $response = $this->response->createOnly(true)->download($file, $name);
 
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertRegExp("/attachment; filename=($name|\"$name\")/", $response->headers->get('content-disposition'));
+        self::assertEquals(200, $response->getStatusCode());
+        self::assertRegExp("/attachment; filename=($name|\"$name\")/", $response->headers->get('content-disposition'));
     }
 
     /**
@@ -158,8 +158,8 @@ class ResponseTest extends TestCase
 
         $response = $this->response->createOnly(true)->download($file, null, [], 'inline');
 
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertRegExp(
+        self::assertEquals(200, $response->getStatusCode());
+        self::assertRegExp(
             '/inline; filename=(empty.txt|"empty.txt")/',
             $response->headers->get('content-disposition')
         );

--- a/tests/Tus/AbstractTusTest.php
+++ b/tests/Tus/AbstractTusTest.php
@@ -36,16 +36,16 @@ class AbstractTusTest extends TestCase
      */
     public function it_sets_and_gets_cache() : void
     {
-        $this->assertInstanceOf(FileStore::class, $this->tus->getCache());
+        self::assertInstanceOf(FileStore::class, $this->tus->getCache());
 
         $this->tus->setCache('redis');
 
-        $this->assertInstanceOf(RedisStore::class, $this->tus->getCache());
+        self::assertInstanceOf(RedisStore::class, $this->tus->getCache());
 
         $fileStore = new FileStore;
 
-        $this->assertInstanceOf(TusServer::class, $this->tus->setCache($fileStore));
-        $this->assertInstanceOf(FileStore::class, $this->tus->getCache());
+        self::assertInstanceOf(TusServer::class, $this->tus->setCache($fileStore));
+        self::assertInstanceOf(FileStore::class, $this->tus->getCache());
     }
 
     /**
@@ -56,9 +56,9 @@ class AbstractTusTest extends TestCase
      */
     public function it_sets_and_gets_api_path() : void
     {
-        $this->assertEquals('/files', $this->tus->getApiPath());
-        $this->assertInstanceOf(TusServer::class, $this->tus->setApiPath('/api'));
-        $this->assertEquals('/api', $this->tus->getApiPath());
+        self::assertEquals('/files', $this->tus->getApiPath());
+        self::assertInstanceOf(TusServer::class, $this->tus->setApiPath('/api'));
+        self::assertEquals('/api', $this->tus->getApiPath());
     }
 
     /**
@@ -69,11 +69,11 @@ class AbstractTusTest extends TestCase
      */
     public function it_sets_and_gets_event_dispatcher() : void
     {
-        $this->assertInstanceOf(EventDispatcher::class, $this->tus->event());
+        self::assertInstanceOf(EventDispatcher::class, $this->tus->event());
 
         $eventDispatcher = new EventDispatcher();
 
-        $this->assertInstanceOf(TusServer::class, $this->tus->setDispatcher($eventDispatcher));
-        $this->assertEquals($eventDispatcher, $this->tus->event());
+        self::assertInstanceOf(TusServer::class, $this->tus->setDispatcher($eventDispatcher));
+        self::assertEquals($eventDispatcher, $this->tus->event());
     }
 }

--- a/tests/Tus/ClientTest.php
+++ b/tests/Tus/ClientTest.php
@@ -101,9 +101,9 @@ class ClientTest extends TestCase
 
         $this->tusClient->file($file);
 
-        $this->assertEquals($file, $this->tusClient->getFilePath());
-        $this->assertEquals('data.txt', $this->tusClient->getFileName());
-        $this->assertEquals(filesize($file), $this->tusClient->getFileSize());
+        self::assertEquals($file, $this->tusClient->getFilePath());
+        self::assertEquals('data.txt', $this->tusClient->getFileName());
+        self::assertEquals(filesize($file), $this->tusClient->getFileSize());
     }
 
     /**
@@ -114,9 +114,9 @@ class ClientTest extends TestCase
      */
     public function it_sets_and_gets_filename() : void
     {
-        $this->assertNull($this->tusClient->getFileName());
-        $this->assertInstanceOf(TusClient::class, $this->tusClient->setFileName('file.txt'));
-        $this->assertEquals('file.txt', $this->tusClient->getFileName());
+        self::assertNull($this->tusClient->getFileName());
+        self::assertInstanceOf(TusClient::class, $this->tusClient->setFileName('file.txt'));
+        self::assertEquals('file.txt', $this->tusClient->getFileName());
     }
 
     /**
@@ -132,13 +132,13 @@ class ClientTest extends TestCase
         $filePath = __DIR__ . '/../Fixtures/empty.txt';
 
         $this->tusClient->file($filePath);
-        $this->assertEquals(['filename' => base64_encode('empty.txt')], $this->tusClient->getMetadata());
+        self::assertEquals(['filename' => base64_encode('empty.txt')], $this->tusClient->getMetadata());
 
         $this->tusClient->addMetadata('filename', 'file.mp4');
-        $this->assertEquals(['filename' => base64_encode('file.mp4')], $this->tusClient->getMetadata());
+        self::assertEquals(['filename' => base64_encode('file.mp4')], $this->tusClient->getMetadata());
 
         $this->tusClient->addMetadata('filetype', 'video/mp4');
-        $this->assertEquals([
+        self::assertEquals([
             'filename' => base64_encode('file.mp4'),
             'filetype' => base64_encode('video/mp4'),
         ], $this->tusClient->getMetadata());
@@ -148,13 +148,13 @@ class ClientTest extends TestCase
             'filetype' => 'video/mp4',
         ]);
 
-        $this->assertEquals([
+        self::assertEquals([
             'filename' => base64_encode('file.mp4'),
             'filetype' => base64_encode('video/mp4'),
         ], $this->tusClient->getMetadata());
 
         $this->tusClient->removeMetadata('filetype');
-        $this->assertEquals(['filename' => base64_encode('file.mp4')], $this->tusClient->getMetadata());
+        self::assertEquals(['filename' => base64_encode('file.mp4')], $this->tusClient->getMetadata());
     }
 
     /**
@@ -165,8 +165,8 @@ class ClientTest extends TestCase
      */
     public function it_gets_client() : void
     {
-        $this->assertInstanceOf(Client::class, $this->tusClient->getClient());
-        $this->assertEquals('http://tus.local', $this->tusClient->getClient()->getConfig()['base_uri']);
+        self::assertInstanceOf(Client::class, $this->tusClient->getClient());
+        self::assertEquals('http://tus.local', $this->tusClient->getClient()->getConfig()['base_uri']);
     }
 
     /**
@@ -192,10 +192,10 @@ class ClientTest extends TestCase
 
         $guzzleConfig = $tusClient->getClient()->getConfig();
 
-        $this->assertEquals('http://tus.local', $guzzleConfig['base_uri']);
-        $this->assertEquals(3.14, $guzzleConfig['connect_timeout']);
-        $this->assertFalse($guzzleConfig['allow_redirects']);
-        $this->assertEquals($headers, $guzzleConfig['headers']);
+        self::assertEquals('http://tus.local', $guzzleConfig['base_uri']);
+        self::assertEquals(3.14, $guzzleConfig['connect_timeout']);
+        self::assertFalse($guzzleConfig['allow_redirects']);
+        self::assertEquals($headers, $guzzleConfig['headers']);
     }
 
     /**
@@ -214,10 +214,10 @@ class ClientTest extends TestCase
             ->once()
             ->andReturn($file);
 
-        $this->assertEquals($checksum, $this->tusClientMock->getChecksum());
+        self::assertEquals($checksum, $this->tusClientMock->getChecksum());
 
         $checksum = '74f02d6da32082463e382f2274e85fd8eae3e81f739f8959abc91865656e3b3a';
-        $this->assertInstanceOf(TusClient::class, $this->tusClientMock->setChecksum($checksum));
+        self::assertInstanceOf(TusClient::class, $this->tusClientMock->setChecksum($checksum));
     }
 
     /**
@@ -230,8 +230,8 @@ class ClientTest extends TestCase
     {
         $key = uniqid();
 
-        $this->assertInstanceOf(TusClient::class, $this->tusClient->setKey($key));
-        $this->assertEquals($key, $this->tusClient->getKey());
+        self::assertInstanceOf(TusClient::class, $this->tusClient->setKey($key));
+        self::assertEquals($key, $this->tusClient->getKey());
     }
 
     /**
@@ -263,7 +263,7 @@ class ClientTest extends TestCase
             ->once()
             ->andReturn($cacheMock);
 
-        $this->assertEquals($url, $this->tusClientMock->getUrl());
+        self::assertEquals($url, $this->tusClientMock->getUrl());
     }
 
     /**
@@ -306,9 +306,9 @@ class ClientTest extends TestCase
      */
     public function it_sets_and_gets_checksum_algorithm() : void
     {
-        $this->assertEquals('sha256', $this->tusClient->getChecksumAlgorithm());
-        $this->assertInstanceOf(TusClient::class, $this->tusClient->setChecksumAlgorithm('crc32'));
-        $this->assertEquals('crc32', $this->tusClient->getChecksumAlgorithm());
+        self::assertEquals('sha256', $this->tusClient->getChecksumAlgorithm());
+        self::assertInstanceOf(TusClient::class, $this->tusClient->setChecksumAlgorithm('crc32'));
+        self::assertEquals('crc32', $this->tusClient->getChecksumAlgorithm());
     }
 
     /**
@@ -328,10 +328,10 @@ class ClientTest extends TestCase
             ->once()
             ->andReturn($key);
 
-        $this->assertFalse($this->tusClientMock->isPartial());
-        $this->assertInstanceOf(TusClient::class, $this->tusClientMock->seek(100));
-        $this->assertTrue($this->tusClientMock->isPartial());
-        $this->assertEquals(100, $this->tusClientMock->getPartialOffset());
+        self::assertFalse($this->tusClientMock->isPartial());
+        self::assertInstanceOf(TusClient::class, $this->tusClientMock->seek(100));
+        self::assertTrue($this->tusClientMock->isPartial());
+        self::assertEquals(100, $this->tusClientMock->getPartialOffset());
     }
 
     /**
@@ -342,9 +342,9 @@ class ClientTest extends TestCase
      */
     public function it_set_state_only_for_partial_equals_false() : void
     {
-        $this->assertFalse($this->tusClientMock->isPartial());
-        $this->assertNull($this->tusClientMock->partial(false));
-        $this->assertFalse($this->tusClientMock->isPartial());
+        self::assertFalse($this->tusClientMock->isPartial());
+        self::assertNull($this->tusClientMock->partial(false));
+        self::assertFalse($this->tusClientMock->isPartial());
     }
 
     /**
@@ -362,8 +362,8 @@ class ClientTest extends TestCase
             ->once()
             ->andReturn($partialKey);
 
-        $this->assertNull($this->tusClientMock->partial());
-        $this->assertTrue($this->tusClientMock->isPartial());
+        self::assertNull($this->tusClientMock->partial());
+        self::assertTrue($this->tusClientMock->isPartial());
     }
 
     /**
@@ -396,7 +396,7 @@ class ClientTest extends TestCase
             ->once()
             ->andReturn($cacheMock);
 
-        $this->assertFalse($this->tusClientMock->isExpired());
+        self::assertFalse($this->tusClientMock->isExpired());
     }
 
     /**
@@ -429,7 +429,7 @@ class ClientTest extends TestCase
             ->once()
             ->andReturn($cacheMock);
 
-        $this->assertTrue($this->tusClientMock->isExpired());
+        self::assertTrue($this->tusClientMock->isExpired());
     }
 
     /**
@@ -458,7 +458,7 @@ class ClientTest extends TestCase
             ->with($bytes, $offset)
             ->andReturn($bytes);
 
-        $this->assertEquals($bytes, $this->tusClientMock->upload($bytes));
+        self::assertEquals($bytes, $this->tusClientMock->upload($bytes));
     }
 
     /**
@@ -492,7 +492,7 @@ class ClientTest extends TestCase
             ->with($bytes, $offset)
             ->andReturn($bytes);
 
-        $this->assertEquals($bytes, $this->tusClientMock->upload());
+        self::assertEquals($bytes, $this->tusClientMock->upload());
     }
 
     /**
@@ -558,7 +558,7 @@ class ClientTest extends TestCase
             ->with($bytes, $offset)
             ->andReturn($bytes);
 
-        $this->assertEquals($bytes, $this->tusClientMock->upload($bytes));
+        self::assertEquals($bytes, $this->tusClientMock->upload($bytes));
     }
 
     /**
@@ -598,7 +598,7 @@ class ClientTest extends TestCase
             ->with($bytes, $offset)
             ->andReturn($bytes);
 
-        $this->assertEquals($bytes, $this->tusClientMock->upload($bytes));
+        self::assertEquals($bytes, $this->tusClientMock->upload($bytes));
     }
 
     /**
@@ -631,7 +631,7 @@ class ClientTest extends TestCase
             ->once()
             ->andThrow(new FileException);
 
-        $this->assertFalse($this->tusClientMock->getOffset());
+        self::assertFalse($this->tusClientMock->getOffset());
     }
 
     /**
@@ -646,7 +646,7 @@ class ClientTest extends TestCase
             ->once()
             ->andThrow(m::mock(ClientException::class));
 
-        $this->assertFalse($this->tusClientMock->getOffset());
+        self::assertFalse($this->tusClientMock->getOffset());
     }
 
     /**
@@ -661,7 +661,7 @@ class ClientTest extends TestCase
             ->once()
             ->andReturn(100);
 
-        $this->assertEquals(100, $this->tusClientMock->getOffset());
+        self::assertEquals(100, $this->tusClientMock->getOffset());
     }
 
     /**
@@ -702,7 +702,7 @@ class ClientTest extends TestCase
             ->with('upload-offset')
             ->andReturn([100]);
 
-        $this->assertEquals(100, $this->tusClientMock->sendHeadRequest());
+        self::assertEquals(100, $this->tusClientMock->sendHeadRequest());
     }
 
     /**
@@ -1138,7 +1138,7 @@ class ClientTest extends TestCase
             ->with('upload-offset')
             ->andReturn([$bytes]);
 
-        $this->assertEquals($bytes, $this->tusClientMock->sendPatchRequest($bytes, $offset));
+        self::assertEquals($bytes, $this->tusClientMock->sendPatchRequest($bytes, $offset));
     }
 
     /**
@@ -1202,7 +1202,7 @@ class ClientTest extends TestCase
             ->with('upload-offset')
             ->andReturn([$bytes]);
 
-        $this->assertEquals($bytes, $this->tusClientMock->sendPatchRequest($bytes, $offset));
+        self::assertEquals($bytes, $this->tusClientMock->sendPatchRequest($bytes, $offset));
     }
 
     /**
@@ -1280,7 +1280,7 @@ class ClientTest extends TestCase
             ])
             ->andReturn($responseMock);
 
-        $this->assertEquals('http://tus-server/files/' . $key, $this->tusClientMock->create($key));
+        self::assertEquals('http://tus-server/files/' . $key, $this->tusClientMock->create($key));
     }
 
     /**
@@ -1364,7 +1364,7 @@ class ClientTest extends TestCase
             ])
             ->andReturn($responseMock);
 
-        $this->assertEquals('http://tus-server/files/' . $key, $this->tusClientMock->create($key));
+        self::assertEquals('http://tus-server/files/' . $key, $this->tusClientMock->create($key));
     }
 
     /**
@@ -1472,7 +1472,7 @@ class ClientTest extends TestCase
             ])
             ->andReturn($responseMock);
 
-        $this->assertEquals(
+        self::assertEquals(
             $checksum,
             $this->tusClientMock->concat($key, $partials[0], $partials[1], $partials[2])
         );
@@ -1618,7 +1618,7 @@ class ClientTest extends TestCase
 
         $response = $this->tusClientMock->delete();
 
-        $this->assertNull($response);
+        self::assertNull($response);
     }
 
     /**
@@ -1664,7 +1664,7 @@ class ClientTest extends TestCase
 
         $response = $this->tusClientMock->delete();
 
-        $this->assertNull($response);
+        self::assertNull($response);
     }
 
     /**
@@ -1710,7 +1710,7 @@ class ClientTest extends TestCase
 
         $response = $this->tusClientMock->delete();
 
-        $this->assertNull($response);
+        self::assertNull($response);
     }
 
     /**
@@ -1731,8 +1731,8 @@ class ClientTest extends TestCase
 
         $data = $this->tusClientMock->getData($offset, $dataLength);
 
-        $this->assertEquals($dataLength, \strlen($data));
-        $this->assertEquals(
+        self::assertEquals($dataLength, \strlen($data));
+        self::assertEquals(
             'The Project Gutenberg EBook of The Adventures of Sherlock Holmes by Sir Arthur Conan Doyle.',
             trim($data)
         );
@@ -1756,8 +1756,8 @@ class ClientTest extends TestCase
 
         $data = $this->tusClientMock->getData($offset, $dataLength);
 
-        $this->assertEquals($dataLength, \strlen($data));
-        $this->assertEquals('Sherlock Holmes', $data);
+        self::assertEquals($dataLength, \strlen($data));
+        self::assertEquals('Sherlock Holmes', $data);
     }
 
     /**
@@ -1780,7 +1780,7 @@ class ClientTest extends TestCase
             ->once()
             ->andReturn('crc32');
 
-        $this->assertEquals('crc32 ' . base64_encode($checksum), $this->tusClientMock->getUploadChecksumHeader());
+        self::assertEquals('crc32 ' . base64_encode($checksum), $this->tusClientMock->getUploadChecksumHeader());
     }
 
     /**
@@ -1794,17 +1794,17 @@ class ClientTest extends TestCase
 
         $this->tusClientMock->file($filePath);
 
-        $this->assertEquals('filename ' . base64_encode('empty.txt'), $this->tusClientMock->getUploadMetadataHeader());
+        self::assertEquals('filename ' . base64_encode('empty.txt'), $this->tusClientMock->getUploadMetadataHeader());
 
         $this->tusClientMock->addMetadata('filename', 'test.txt');
 
         $metadata = 'filename ' . base64_encode('test.txt');
-        $this->assertEquals($metadata, $this->tusClientMock->getUploadMetadataHeader());
+        self::assertEquals($metadata, $this->tusClientMock->getUploadMetadataHeader());
 
         $this->tusClientMock->addMetadata('filetype', 'plain/text');
 
         $metadata .= ',filetype ' . base64_encode('plain/text');
-        $this->assertEquals($metadata, $this->tusClientMock->getUploadMetadataHeader());
+        self::assertEquals($metadata, $this->tusClientMock->getUploadMetadataHeader());
     }
 
     /**

--- a/tests/Tus/ServerTest.php
+++ b/tests/Tus/ServerTest.php
@@ -91,11 +91,11 @@ class ServerTest extends TestCase
      */
     public function it_sets_and_gets_upload_dir() : void
     {
-        $this->assertEquals(\dirname(__DIR__, 2) . '/uploads', $this->tusServer->getUploadDir());
+        self::assertEquals(\dirname(__DIR__, 2) . '/uploads', $this->tusServer->getUploadDir());
 
         $this->tusServer->setUploadDir(\dirname(__DIR__) . '/storage');
 
-        $this->assertEquals(\dirname(__DIR__) . '/storage', $this->tusServer->getUploadDir());
+        self::assertEquals(\dirname(__DIR__) . '/storage', $this->tusServer->getUploadDir());
     }
 
     /**
@@ -106,7 +106,7 @@ class ServerTest extends TestCase
      */
     public function it_gets_a_request() : void
     {
-        $this->assertInstanceOf(Request::class, $this->tusServer->getRequest());
+        self::assertInstanceOf(Request::class, $this->tusServer->getRequest());
     }
 
     /**
@@ -117,7 +117,7 @@ class ServerTest extends TestCase
      */
     public function it_gets_a_response() : void
     {
-        $this->assertInstanceOf(Response::class, $this->tusServer->getResponse());
+        self::assertInstanceOf(Response::class, $this->tusServer->getResponse());
     }
 
     /**
@@ -130,7 +130,7 @@ class ServerTest extends TestCase
         $filePath = __DIR__ . '/../Fixtures/empty.txt';
         $checksum = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
 
-        $this->assertEquals($checksum, $this->tusServer->getServerChecksum($filePath));
+        self::assertEquals($checksum, $this->tusServer->getServerChecksum($filePath));
     }
 
     /**
@@ -140,7 +140,7 @@ class ServerTest extends TestCase
      */
     public function it_gets_checksum_algorithm() : void
     {
-        $this->assertEquals('sha256', $this->tusServerMock->getChecksumAlgorithm());
+        self::assertEquals('sha256', $this->tusServerMock->getChecksumAlgorithm());
 
         $checksumAlgorithm = 'sha1';
 
@@ -150,7 +150,7 @@ class ServerTest extends TestCase
             ->headers
             ->set('Upload-Checksum', $checksumAlgorithm . ' checksum');
 
-        $this->assertEquals($checksumAlgorithm, $this->tusServerMock->getChecksumAlgorithm());
+        self::assertEquals($checksumAlgorithm, $this->tusServerMock->getChecksumAlgorithm());
     }
 
     /**
@@ -161,8 +161,8 @@ class ServerTest extends TestCase
      */
     public function it_sets_and_gets_middleware() : void
     {
-        $this->assertInstanceOf(Middleware::class, $this->tusServerMock->middleware());
-        $this->assertInstanceOf(Server::class, $this->tusServerMock->setMiddleware(new Middleware));
+        self::assertInstanceOf(Middleware::class, $this->tusServerMock->middleware());
+        self::assertInstanceOf(Server::class, $this->tusServerMock->setMiddleware(new Middleware));
     }
 
     /**
@@ -173,9 +173,9 @@ class ServerTest extends TestCase
      */
     public function it_sets_and_gets_max_upload_size() : void
     {
-        $this->assertEquals(0, $this->tusServerMock->getMaxUploadSize());
-        $this->assertInstanceOf(TusServer::class, $this->tusServerMock->setMaxUploadSize(1000));
-        $this->assertEquals(1000, $this->tusServerMock->getMaxUploadSize());
+        self::assertEquals(0, $this->tusServerMock->getMaxUploadSize());
+        self::assertInstanceOf(TusServer::class, $this->tusServerMock->setMaxUploadSize(1000));
+        self::assertEquals(1000, $this->tusServerMock->getMaxUploadSize());
     }
 
     /**
@@ -193,8 +193,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->serve();
 
-        $this->assertEquals(405, $response->getStatusCode());
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(405, $response->getStatusCode());
+        self::assertEmpty($response->getContent());
     }
 
     /**
@@ -240,9 +240,9 @@ class ServerTest extends TestCase
 
         $response = $tusServerMock->serve();
 
-        $this->assertEquals(412, $response->getStatusCode());
-        $this->assertEquals('1.0.0', $response->headers->get('Tus-Version'));
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(412, $response->getStatusCode());
+        self::assertEquals('1.0.0', $response->headers->get('Tus-Version'));
+        self::assertEmpty($response->getContent());
     }
 
     /**
@@ -291,7 +291,7 @@ class ServerTest extends TestCase
             ->once()
             ->andReturn(m::mock(HttpResponse::class));
 
-        $this->assertInstanceOf(HttpResponse::class, $tusServerMock->serve());
+        self::assertInstanceOf(HttpResponse::class, $tusServerMock->serve());
     }
 
     /**
@@ -336,7 +336,7 @@ class ServerTest extends TestCase
                 ->once()
                 ->andReturn(m::mock(HttpResponse::class));
 
-            $this->assertInstanceOf(HttpResponse::class, $tusServerMock->serve());
+            self::assertInstanceOf(HttpResponse::class, $tusServerMock->serve());
         }
     }
 
@@ -381,7 +381,7 @@ class ServerTest extends TestCase
             ->once()
             ->andReturn(m::mock(HttpResponse::class));
 
-        $this->assertInstanceOf(HttpResponse::class, $tusServerMock->serve());
+        self::assertInstanceOf(HttpResponse::class, $tusServerMock->serve());
     }
 
     /**
@@ -425,7 +425,7 @@ class ServerTest extends TestCase
             ->once()
             ->andReturn(m::mock(HttpResponse::class));
 
-        $this->assertInstanceOf(HttpResponse::class, $tusServerMock->serve());
+        self::assertInstanceOf(HttpResponse::class, $tusServerMock->serve());
     }
 
     /**
@@ -459,7 +459,7 @@ class ServerTest extends TestCase
             ->skip(Cors::class, GlobalHeaders::class)
             ->add($corsMock, $headersMock);
 
-        $this->assertNull($this->tusServerMock->applyMiddleware());
+        self::assertNull($this->tusServerMock->applyMiddleware());
     }
 
     /**
@@ -471,8 +471,8 @@ class ServerTest extends TestCase
     {
         $response = $this->tusServer->handleHead();
 
-        $this->assertEquals(400, $response->getStatusCode());
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(400, $response->getStatusCode());
+        self::assertEmpty($response->getContent());
     }
 
     /**
@@ -491,21 +491,21 @@ class ServerTest extends TestCase
         $response = $this->tusServerMock->handleOptions();
         $headers  = $response->headers->all();
 
-        $this->assertArrayNotHasKey('tus-max-size', $headers);
-        $this->assertNull(current($headers['access-control-allow-origin']));
-        $this->assertEquals(implode(',', self::ALLOWED_HTTP_VERBS), current($headers['allow']));
-        $this->assertEquals(implode(',', self::ALLOWED_HTTP_VERBS), current($headers['access-control-allow-methods']));
-        $this->assertEquals(86400, current($headers['access-control-max-age']));
-        $this->assertEquals('1.0.0', current($headers['tus-version']));
-        $this->assertEquals(
+        self::assertArrayNotHasKey('tus-max-size', $headers);
+        self::assertNull(current($headers['access-control-allow-origin']));
+        self::assertEquals(implode(',', self::ALLOWED_HTTP_VERBS), current($headers['allow']));
+        self::assertEquals(implode(',', self::ALLOWED_HTTP_VERBS), current($headers['access-control-allow-methods']));
+        self::assertEquals(86400, current($headers['access-control-max-age']));
+        self::assertEquals('1.0.0', current($headers['tus-version']));
+        self::assertEquals(
             'Origin, X-Requested-With, Content-Type, Content-Length, Upload-Key, Upload-Checksum, Upload-Length, Upload-Offset, Tus-Version, Tus-Resumable, Upload-Metadata',
             current($headers['access-control-allow-headers'])
         );
-        $this->assertEquals(
+        self::assertEquals(
             'Upload-Key, Upload-Checksum, Upload-Length, Upload-Offset, Upload-Metadata, Tus-Version, Tus-Resumable, Tus-Extension, Location',
             current($headers['access-control-expose-headers'])
         );
-        $this->assertEquals(
+        self::assertEquals(
             'creation,termination,checksum,expiration,concatenation',
             current($headers['tus-extension'])
         );
@@ -532,9 +532,9 @@ class ServerTest extends TestCase
         $response = $this->tusServerMock->handleOptions();
         $headers  = $response->headers->all();
 
-        $this->assertArrayHasKey('tus-max-size', $headers);
-        $this->assertEquals(1000, current($headers['tus-max-size']));
-        $this->assertEquals('1.0.0', current($headers['tus-version']));
+        self::assertArrayHasKey('tus-max-size', $headers);
+        self::assertEquals(1000, current($headers['tus-max-size']));
+        self::assertEquals('1.0.0', current($headers['tus-version']));
     }
 
     /**
@@ -574,8 +574,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handleHead();
 
-        $this->assertEquals(404, $response->getStatusCode());
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(404, $response->getStatusCode());
+        self::assertEmpty($response->getContent());
     }
 
     /**
@@ -616,8 +616,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handleHead();
 
-        $this->assertEquals(410, $response->getStatusCode());
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(410, $response->getStatusCode());
+        self::assertEmpty($response->getContent());
     }
 
     /**
@@ -660,12 +660,12 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handleHead();
 
-        $this->assertEmpty($response->getContent());
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals(49, $response->headers->get('upload-offset'));
-        $this->assertNull($response->headers->get('upload-concat'));
-        $this->assertEquals('1.0.0', $response->headers->get('tus-resumable'));
-        $this->assertEquals('no-store, private', $response->headers->get('cache-control'));
+        self::assertEmpty($response->getContent());
+        self::assertEquals(200, $response->getStatusCode());
+        self::assertEquals(49, $response->headers->get('upload-offset'));
+        self::assertNull($response->headers->get('upload-concat'));
+        self::assertEquals('1.0.0', $response->headers->get('tus-resumable'));
+        self::assertEquals('no-store, private', $response->headers->get('cache-control'));
     }
 
     /**
@@ -708,12 +708,12 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handleHead();
 
-        $this->assertEmpty($response->getContent());
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals(49, $response->headers->get('upload-offset'));
-        $this->assertEquals('partial', $response->headers->get('upload-concat'));
-        $this->assertEquals('1.0.0', $response->headers->get('tus-resumable'));
-        $this->assertEquals('no-store, private', $response->headers->get('cache-control'));
+        self::assertEmpty($response->getContent());
+        self::assertEquals(200, $response->getStatusCode());
+        self::assertEquals(49, $response->headers->get('upload-offset'));
+        self::assertEquals('partial', $response->headers->get('upload-concat'));
+        self::assertEquals('1.0.0', $response->headers->get('tus-resumable'));
+        self::assertEquals('no-store, private', $response->headers->get('cache-control'));
     }
 
     /**
@@ -756,12 +756,12 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handleHead();
 
-        $this->assertEmpty($response->getContent());
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertNull($response->headers->get('upload-offset'));
-        $this->assertEquals('final', $response->headers->get('upload-concat'));
-        $this->assertEquals('1.0.0', $response->headers->get('tus-resumable'));
-        $this->assertEquals('no-store, private', $response->headers->get('cache-control'));
+        self::assertEmpty($response->getContent());
+        self::assertEquals(200, $response->getStatusCode());
+        self::assertNull($response->headers->get('upload-offset'));
+        self::assertEquals('final', $response->headers->get('upload-concat'));
+        self::assertEquals('1.0.0', $response->headers->get('tus-resumable'));
+        self::assertEquals('no-store, private', $response->headers->get('cache-control'));
     }
 
     /**
@@ -782,8 +782,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handlePost();
 
-        $this->assertEquals(400, $response->getStatusCode());
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(400, $response->getStatusCode());
+        self::assertEmpty($response->getContent());
     }
 
     /**
@@ -830,8 +830,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handlePost();
 
-        $this->assertEquals(413, $response->getStatusCode());
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(413, $response->getStatusCode());
+        self::assertEmpty($response->getContent());
     }
 
     /**
@@ -886,7 +886,7 @@ class ServerTest extends TestCase
             ->once()
             ->andReturn(new HttpResponse);
 
-        $this->assertInstanceOf(HttpResponse::class, $this->tusServerMock->handlePost());
+        self::assertInstanceOf(HttpResponse::class, $this->tusServerMock->handlePost());
     }
 
     /**
@@ -1010,11 +1010,11 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handlePost();
 
-        $this->assertEmpty($response->getContent());
-        $this->assertEquals(201, $response->getStatusCode());
-        $this->assertEquals($location, $response->headers->get('location'));
-        $this->assertEquals($expiresAt, $response->headers->get('upload-expires'));
-        $this->assertEquals('1.0.0', $response->headers->get('tus-resumable'));
+        self::assertEmpty($response->getContent());
+        self::assertEquals(201, $response->getStatusCode());
+        self::assertEquals($location, $response->headers->get('location'));
+        self::assertEquals($expiresAt, $response->headers->get('upload-expires'));
+        self::assertEquals('1.0.0', $response->headers->get('tus-resumable'));
     }
 
     /**
@@ -1128,11 +1128,11 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handlePost();
 
-        $this->assertEmpty($response->getContent());
-        $this->assertEquals(201, $response->getStatusCode());
-        $this->assertEquals($location, $response->headers->get('location'));
-        $this->assertEquals($expiresAt, $response->headers->get('upload-expires'));
-        $this->assertEquals('1.0.0', $response->headers->get('tus-resumable'));
+        self::assertEmpty($response->getContent());
+        self::assertEquals(201, $response->getStatusCode());
+        self::assertEquals($location, $response->headers->get('location'));
+        self::assertEquals($expiresAt, $response->headers->get('upload-expires'));
+        self::assertEquals('1.0.0', $response->headers->get('tus-resumable'));
     }
 
     /**
@@ -1305,9 +1305,9 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handleConcatenation($fileName, $filePath . $fileName);
 
-        $this->assertEquals(201, $response->getStatusCode());
-        $this->assertEquals($location, $response->headers->get('location'));
-        $this->assertEquals('1.0.0', $response->headers->get('tus-resumable'));
+        self::assertEquals(201, $response->getStatusCode());
+        self::assertEquals($location, $response->headers->get('location'));
+        self::assertEquals('1.0.0', $response->headers->get('tus-resumable'));
     }
 
     /**
@@ -1429,8 +1429,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handleConcatenation($fileName, $filePath . $fileName);
 
-        $this->assertEquals(460, $response->getStatusCode());
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(460, $response->getStatusCode());
+        self::assertEmpty($response->getContent());
     }
 
     /**
@@ -1469,8 +1469,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handlePatch();
 
-        $this->assertEquals(410, $response->getStatusCode());
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(410, $response->getStatusCode());
+        self::assertEmpty($response->getContent());
     }
 
     /**
@@ -1534,8 +1534,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handlePatch();
 
-        $this->assertEquals(409, $response->getStatusCode());
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(409, $response->getStatusCode());
+        self::assertEmpty($response->getContent());
     }
 
     /**
@@ -1637,8 +1637,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handlePatch();
 
-        $this->assertEquals(422, $response->getStatusCode());
-        $this->assertEquals('Unable to open file.', $response->getContent());
+        self::assertEquals(422, $response->getStatusCode());
+        self::assertEquals('Unable to open file.', $response->getContent());
     }
 
     /**
@@ -1740,8 +1740,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handlePatch();
 
-        $this->assertEquals(416, $response->getStatusCode());
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(416, $response->getStatusCode());
+        self::assertEmpty($response->getContent());
     }
 
     /**
@@ -1843,8 +1843,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handlePatch();
 
-        $this->assertEquals(100, $response->getStatusCode());
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(100, $response->getStatusCode());
+        self::assertEmpty($response->getContent());
     }
 
     /**
@@ -1900,8 +1900,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handlePatch();
 
-        $this->assertEquals(403, $response->getStatusCode());
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(403, $response->getStatusCode());
+        self::assertEmpty($response->getContent());
     }
 
     /**
@@ -2003,8 +2003,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handlePatch();
 
-        $this->assertEquals(460, $response->getStatusCode());
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(460, $response->getStatusCode());
+        self::assertEmpty($response->getContent());
     }
 
     /**
@@ -2123,12 +2123,12 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handlePatch();
 
-        $this->assertEquals(204, $response->getStatusCode());
-        $this->assertEquals($expiresAt, $response->headers->get('upload-expires'));
-        $this->assertEquals($fileSize, $response->headers->get('upload-offset'));
-        $this->assertEquals('1.0.0', $response->headers->get('tus-resumable'));
-        $this->assertEquals('application/offset+octet-stream', $response->headers->get('content-type'));
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(204, $response->getStatusCode());
+        self::assertEquals($expiresAt, $response->headers->get('upload-expires'));
+        self::assertEquals($fileSize, $response->headers->get('upload-offset'));
+        self::assertEquals('1.0.0', $response->headers->get('tus-resumable'));
+        self::assertEquals('application/offset+octet-stream', $response->headers->get('content-type'));
+        self::assertEmpty($response->getContent());
     }
 
     /**
@@ -2242,12 +2242,12 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handlePatch();
 
-        $this->assertEquals(204, $response->getStatusCode());
-        $this->assertEquals($expiresAt, $response->headers->get('upload-expires'));
-        $this->assertEquals(100, $response->headers->get('upload-offset'));
-        $this->assertEquals('1.0.0', $response->headers->get('tus-resumable'));
-        $this->assertEquals('application/offset+octet-stream', $response->headers->get('content-type'));
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(204, $response->getStatusCode());
+        self::assertEquals($expiresAt, $response->headers->get('upload-expires'));
+        self::assertEquals(100, $response->headers->get('upload-offset'));
+        self::assertEquals('1.0.0', $response->headers->get('tus-resumable'));
+        self::assertEquals('application/offset+octet-stream', $response->headers->get('content-type'));
+        self::assertEmpty($response->getContent());
     }
 
     /**
@@ -2284,7 +2284,7 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handleGet();
 
-        $this->assertEquals(200, $response->getStatusCode());
+        self::assertEquals(200, $response->getStatusCode());
     }
 
     /**
@@ -2321,7 +2321,7 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handleGet();
 
-        $this->assertEquals(200, $response->getStatusCode());
+        self::assertEquals(200, $response->getStatusCode());
     }
 
     /**
@@ -2358,8 +2358,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handleGet();
 
-        $this->assertEquals(404, $response->getStatusCode());
-        $this->assertEquals('404 upload not found.', $response->getContent());
+        self::assertEquals(404, $response->getStatusCode());
+        self::assertEquals('404 upload not found.', $response->getContent());
     }
 
     /**
@@ -2398,8 +2398,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handleGet();
 
-        $this->assertEquals(404, $response->getStatusCode());
-        $this->assertEquals('404 upload not found.', $response->getContent());
+        self::assertEquals(404, $response->getStatusCode());
+        self::assertEquals('404 upload not found.', $response->getContent());
     }
 
     /**
@@ -2440,8 +2440,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handleGet();
 
-        $this->assertEquals(404, $response->getStatusCode());
-        $this->assertEquals('404 upload not found.', $response->getContent());
+        self::assertEquals(404, $response->getStatusCode());
+        self::assertEquals('404 upload not found.', $response->getContent());
     }
 
     /**
@@ -2496,8 +2496,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handleGet();
 
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertRegExp(
+        self::assertEquals(200, $response->getStatusCode());
+        self::assertRegExp(
             "/attachment; filename=($fileName|\"$fileName\")/",
             $response->headers->get('content-disposition')
         );
@@ -2538,8 +2538,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handleDelete();
 
-        $this->assertEquals(404, $response->getStatusCode());
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(404, $response->getStatusCode());
+        self::assertEmpty($response->getContent());
     }
 
     /**
@@ -2585,8 +2585,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handleDelete();
 
-        $this->assertEquals(410, $response->getStatusCode());
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(410, $response->getStatusCode());
+        self::assertEmpty($response->getContent());
     }
 
     /**
@@ -2646,10 +2646,10 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handleDelete();
 
-        $this->assertEmpty($response->getContent());
-        $this->assertEquals(204, $response->getStatusCode());
-        $this->assertEquals('1.0.0', $response->headers->get('tus-resumable'));
-        $this->assertEquals('termination', $response->headers->get('tus-extension'));
+        self::assertEmpty($response->getContent());
+        self::assertEquals(204, $response->getStatusCode());
+        self::assertEquals('1.0.0', $response->headers->get('tus-resumable'));
+        self::assertEquals('termination', $response->headers->get('tus-extension'));
 
         $mock->disable();
     }
@@ -2673,15 +2673,15 @@ class ServerTest extends TestCase
             'Cache-Control' => 'no-store',
         ];
 
-        $this->assertEquals($headers, $this->tusServerMock->getHeadersForHeadRequest($fileMeta));
-        $this->assertEquals(
+        self::assertEquals($headers, $this->tusServerMock->getHeadersForHeadRequest($fileMeta));
+        self::assertEquals(
             $headers + ['Upload-Concat' => 'partial'],
             $this->tusServerMock->getHeadersForHeadRequest(['upload_type' => 'partial'] + $fileMeta)
         );
 
         unset($headers['Upload-Offset']);
 
-        $this->assertEquals(
+        self::assertEquals(
             $headers + ['Upload-Concat' => 'final'],
             $this->tusServerMock->getHeadersForHeadRequest(['upload_type' => 'final'] + $fileMeta)
         );
@@ -2719,14 +2719,14 @@ class ServerTest extends TestCase
 
         $details = $file->details();
 
-        $this->assertInstanceOf(File::class, $file);
-        $this->assertEquals($fileName, $details['name']);
-        $this->assertEquals($fileSize, $details['size']);
-        $this->assertEquals(0, $details['offset']);
-        $this->assertEquals($filePath, $details['file_path']);
-        $this->assertEquals($location, $details['location']);
-        $this->assertEquals($createdAt, $details['created_at']);
-        $this->assertEquals($expiresAt, $details['expires_at']);
+        self::assertInstanceOf(File::class, $file);
+        self::assertEquals($fileName, $details['name']);
+        self::assertEquals($fileSize, $details['size']);
+        self::assertEquals(0, $details['offset']);
+        self::assertEquals($filePath, $details['file_path']);
+        self::assertEquals($location, $details['location']);
+        self::assertEquals($createdAt, $details['created_at']);
+        self::assertEquals($expiresAt, $details['expires_at']);
     }
 
     /**
@@ -2752,7 +2752,7 @@ class ServerTest extends TestCase
 
         $mock->enable();
 
-        $this->assertEquals("md5,sha1,sha256,'haval256,3'", $this->tusServerMock->getSupportedHashAlgorithms());
+        self::assertEquals("md5,sha1,sha256,'haval256,3'", $this->tusServerMock->getSupportedHashAlgorithms());
 
         $mock->disable();
     }
@@ -2766,7 +2766,7 @@ class ServerTest extends TestCase
     {
         $response = $this->tusServerMock->getClientChecksum();
 
-        $this->assertEmpty($response);
+        self::assertEmpty($response);
     }
 
     /**
@@ -2802,8 +2802,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->getClientChecksum();
 
-        $this->assertEquals(400, $response->getStatusCode());
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(400, $response->getStatusCode());
+        self::assertEmpty($response->getContent());
 
         $mock->disable();
     }
@@ -2839,8 +2839,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->getClientChecksum();
 
-        $this->assertEquals(400, $response->getStatusCode());
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(400, $response->getStatusCode());
+        self::assertEmpty($response->getContent());
 
         $mock->disable();
     }
@@ -2861,7 +2861,7 @@ class ServerTest extends TestCase
             ->headers
             ->set('Upload-Checksum', 'sha1 ' . base64_encode($checksum));
 
-        $this->assertEquals($checksum, $this->tusServerMock->getClientChecksum());
+        self::assertEquals($checksum, $this->tusServerMock->getClientChecksum());
     }
 
     /**
@@ -2879,8 +2879,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->getUploadKey();
 
-        $this->assertEquals(400, $response->getStatusCode());
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(400, $response->getStatusCode());
+        self::assertEmpty($response->getContent());
     }
 
     /**
@@ -2892,7 +2892,7 @@ class ServerTest extends TestCase
     {
         $response = $this->tusServerMock->getUploadKey();
 
-        $this->assertNotEmpty($response);
+        self::assertNotEmpty($response);
     }
 
     /**
@@ -2910,7 +2910,7 @@ class ServerTest extends TestCase
             ->headers
             ->set('Upload-Key', $key);
 
-        $this->assertEquals($key, $this->tusServerMock->getUploadKey());
+        self::assertEquals($key, $this->tusServerMock->getUploadKey());
 
         return $key;
     }
@@ -2925,8 +2925,8 @@ class ServerTest extends TestCase
      */
     public function it_gets_upload_key_if_already_set(string $key) : void
     {
-        $this->assertInstanceOf(Server::class, $this->tusServerMock->setUploadKey($key));
-        $this->assertEquals($key, $this->tusServerMock->getUploadKey());
+        self::assertInstanceOf(Server::class, $this->tusServerMock->setUploadKey($key));
+        self::assertEquals($key, $this->tusServerMock->getUploadKey());
     }
 
     /**
@@ -2936,16 +2936,16 @@ class ServerTest extends TestCase
      */
     public function it_checks_expiry_date() : void
     {
-        $this->assertFalse($this->tusServerMock->isExpired(['expires_at' => 'Sat, 09 Dec 2017 00:00:00 GMT']));
+        self::assertFalse($this->tusServerMock->isExpired(['expires_at' => 'Sat, 09 Dec 2017 00:00:00 GMT']));
 
-        $this->assertFalse($this->tusServerMock->isExpired([
+        self::assertFalse($this->tusServerMock->isExpired([
             'expires_at' => 'Thu, 07 Dec 2017 00:00:00 GMT',
             'offset' => 100,
             'size' => 100,
             'file_path' => '/path/to/file.txt',
         ]));
 
-        $this->assertTrue($this->tusServerMock->isExpired([
+        self::assertTrue($this->tusServerMock->isExpired([
             'expires_at' => 'Thu, 07 Dec 2017 00:00:00 GMT',
             'offset' => 100,
             'size' => 1100,
@@ -3015,9 +3015,9 @@ class ServerTest extends TestCase
 
         touch($filePath);
 
-        $this->assertTrue(file_exists($filePath));
+        self::assertTrue(file_exists($filePath));
 
-        $this->assertEquals([
+        self::assertEquals([
             [
                 'expires_at' => 'Thu, 07 Dec 2017 00:00:00 GMT',
                 'offset' => 100,
@@ -3026,7 +3026,7 @@ class ServerTest extends TestCase
             ],
         ], $this->tusServerMock->handleExpiration());
 
-        $this->assertFalse(file_exists($filePath));
+        self::assertFalse(file_exists($filePath));
     }
 
     /**
@@ -3070,7 +3070,7 @@ class ServerTest extends TestCase
 
         $this->tusServerMock->setCache($cacheMock);
 
-        $this->assertEquals([], $this->tusServerMock->handleExpiration());
+        self::assertEquals([], $this->tusServerMock->handleExpiration());
     }
 
     /**
@@ -3086,13 +3086,13 @@ class ServerTest extends TestCase
 
         $this->tusServerMock->setUploadDir($baseDir);
 
-        $this->assertEquals(
+        self::assertEquals(
             $uploadDir,
             $this->tusServerMock->getPathForPartialUpload('checksum_partial')
         );
 
-        $this->assertTrue(file_exists($uploadDir));
-        $this->assertTrue(is_dir($uploadDir));
+        self::assertTrue(file_exists($uploadDir));
+        self::assertTrue(is_dir($uploadDir));
 
         @rmdir($uploadDir);
     }
@@ -3133,7 +3133,7 @@ class ServerTest extends TestCase
 
         $this->tusServerMock->setCache($cacheMock);
 
-        $this->assertEquals($files, $this->tusServerMock->getPartialsMeta($partials));
+        self::assertEquals($files, $this->tusServerMock->getPartialsMeta($partials));
     }
 
     /**
@@ -3144,7 +3144,7 @@ class ServerTest extends TestCase
      */
     public function it_verifies_upload_size() : void
     {
-        $this->assertTrue($this->tusServerMock->verifyUploadSize());
+        self::assertTrue($this->tusServerMock->verifyUploadSize());
 
         $requestMock = m::mock(Request::class, ['file'])->makePartial();
         $requestMock
@@ -3159,8 +3159,8 @@ class ServerTest extends TestCase
             ->twice()
             ->andReturn($requestMock);
 
-        $this->assertInstanceOf(TusServer::class, $this->tusServerMock->setMaxUploadSize(1000));
-        $this->assertTrue($this->tusServerMock->verifyUploadSize());
+        self::assertInstanceOf(TusServer::class, $this->tusServerMock->setMaxUploadSize(1000));
+        self::assertTrue($this->tusServerMock->verifyUploadSize());
 
         $requestMock
             ->getRequest()
@@ -3169,7 +3169,7 @@ class ServerTest extends TestCase
                 'Upload-Length' => 10000,
             ]);
 
-        $this->assertFalse($this->tusServerMock->verifyUploadSize());
+        self::assertFalse($this->tusServerMock->verifyUploadSize());
     }
 
     /**
@@ -3182,9 +3182,9 @@ class ServerTest extends TestCase
         $filePath = __DIR__ . '/../Fixtures/empty.txt';
         $checksum = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
 
-        $this->assertTrue($this->tusServerMock->verifyChecksum('', $filePath));
-        $this->assertFalse($this->tusServerMock->verifyChecksum('invalid', $filePath));
-        $this->assertTrue($this->tusServerMock->verifyChecksum($checksum, $filePath));
+        self::assertTrue($this->tusServerMock->verifyChecksum('', $filePath));
+        self::assertFalse($this->tusServerMock->verifyChecksum('invalid', $filePath));
+        self::assertTrue($this->tusServerMock->verifyChecksum($checksum, $filePath));
     }
 
     /**
@@ -3242,8 +3242,8 @@ class ServerTest extends TestCase
 
         $response = $this->tusServerMock->handlePatch();
 
-        $this->assertEquals(415, $response->getStatusCode());
-        $this->assertEmpty($response->getContent());
+        self::assertEquals(415, $response->getStatusCode());
+        self::assertEmpty($response->getContent());
     }
 
     /**


### PR DESCRIPTION
Assertions are implemented as static methods and should be called that way.