### PR TITLE
handle Guzzle ClientException

### DIFF
--- a/src/Tus/Client.php
+++ b/src/Tus/Client.php
@@ -437,9 +437,13 @@ class Client extends AbstractTus
             $headers += ['Upload-Concat' => 'partial'];
         }
 
-        $response = $this->getClient()->post($this->apiPath, [
-            'headers' => $headers,
-        ]);
+        try {
+            $response = $this->getClient()->post($this->apiPath, [
+                'headers' => $headers,
+            ]);
+        } catch (ClientException $e) {
+            $response = $e->getResponse();
+        }
 
         $statusCode = $response->getStatusCode();
 

--- a/tests/Tus/ClientTest.php
+++ b/tests/Tus/ClientTest.php
@@ -1367,6 +1367,12 @@ class ClientTest extends TestCase
 
         $this->tusClientMock->file($filePath, $fileName);
 
+        $clientExceptionMock = m::mock(ClientException::class);
+        $clientExceptionMock
+            ->shouldReceive('getResponse')
+            ->once()
+            ->andReturn($responseMock);
+
         $guzzleMock
             ->shouldReceive('post')
             ->once()
@@ -1378,7 +1384,7 @@ class ClientTest extends TestCase
                     'Upload-Metadata' => 'filename ' . base64_encode($fileName),
                 ],
             ])
-            ->andReturn($responseMock);
+            ->andThrow($clientExceptionMock);
 
         $this->tusClientMock->create($key);
     }


### PR DESCRIPTION
in case of an 4xx error Guzzle throws a ClientException and the response is inside of that

fixes #323 