### PR TITLE
Add function to upload data on resource creation

### DIFF
--- a/src/Tus/Client.php
+++ b/src/Tus/Client.php
@@ -426,6 +426,26 @@ class Client extends AbstractTus
      */
     public function create(string $key) : string
     {
+        return $this->createWithUpload($key, 0)['location'];
+    }
+
+    /**
+     * Create resource with POST request and upload data using the creation-with-upload extension
+     *
+     * @see https://tus.io/protocols/resumable-upload.html#creation-with-upload
+     *
+     * @param string $key
+     * @param int $bytes -1 => all data; 0 => no data
+     * @return array ['location' => $uploadLocation, 'offset' => $offset]
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function createWithUpload(string $key, int $bytes = -1) : array
+    {
+        $bytes  = $bytes < 0 ? $this->fileSize : $bytes;
+        $data   = '';
+        if ($bytes > 0) {
+            $data = $this->getData(0, $bytes);
+        }
         $headers = $this->headers + [
             'Upload-Length' => $this->fileSize,
             'Upload-Key' => $key,
@@ -433,12 +453,17 @@ class Client extends AbstractTus
             'Upload-Metadata' => $this->getUploadMetadataHeader(),
         ];
 
+        if ($bytes > 0) {
+            $headers += ['Content-Type' => self::HEADER_CONTENT_TYPE];
+            $headers += ['Content-Length' => \strlen($data)];
+        }
         if ($this->isPartial()) {
             $headers += ['Upload-Concat' => 'partial'];
         }
 
         try {
             $response = $this->getClient()->post($this->apiPath, [
+                'body' => $data,
                 'headers' => $headers,
             ]);
         } catch (ClientException $e) {
@@ -452,13 +477,17 @@ class Client extends AbstractTus
         }
 
         $uploadLocation = current($response->getHeader('location'));
+        $offset         = null;
+        if ($bytes > 0) {
+            $offset = current($response->getHeader('upload-offset'));
+        }
 
         $this->getCache()->set($this->getKey(), [
             'location' => $uploadLocation,
             'expires_at' => Carbon::now()->addSeconds($this->getCache()->getTtl())->format($this->getCache()::RFC_7231),
         ]);
 
-        return $uploadLocation;
+        return ['location' => $uploadLocation, 'offset' => $offset];
     }
 
     /**

--- a/src/Tus/Client.php
+++ b/src/Tus/Client.php
@@ -441,11 +441,7 @@ class Client extends AbstractTus
      */
     public function createWithUpload(string $key, int $bytes = -1) : array
     {
-        $bytes  = $bytes < 0 ? $this->fileSize : $bytes;
-        $data   = '';
-        if ($bytes > 0) {
-            $data = $this->getData(0, $bytes);
-        }
+        $bytes   = $bytes < 0 ? $this->fileSize : $bytes;
         $headers = $this->headers + [
             'Upload-Length' => $this->fileSize,
             'Upload-Key' => $key,
@@ -453,7 +449,9 @@ class Client extends AbstractTus
             'Upload-Metadata' => $this->getUploadMetadataHeader(),
         ];
 
+        $data   = '';
         if ($bytes > 0) {
+            $data = $this->getData(0, $bytes);
             $headers += ['Content-Type' => self::HEADER_CONTENT_TYPE];
             $headers += ['Content-Length' => \strlen($data)];
         }

--- a/src/Tus/Client.php
+++ b/src/Tus/Client.php
@@ -477,7 +477,7 @@ class Client extends AbstractTus
         }
 
         $uploadLocation = current($response->getHeader('location'));
-        $offset         = null;
+        $offset         = 0;
         if ($bytes > 0) {
             $offset = current($response->getHeader('upload-offset'));
         }

--- a/tests/Tus/ClientTest.php
+++ b/tests/Tus/ClientTest.php
@@ -1339,10 +1339,10 @@ class ClientTest extends TestCase
 
     public function createWithUploadDataProvider()
     {
-        return array(
+        return [
             [-1],
             [10],
-        );
+        ];
     }
 
     /**

--- a/tests/Tus/ClientTest.php
+++ b/tests/Tus/ClientTest.php
@@ -1175,6 +1175,7 @@ class ClientTest extends TestCase
      * @test
      *
      * @covers ::create
+     * @covers ::createWithUpload
      */
     public function it_creates_a_resource_with_post_request() : void
     {
@@ -1254,6 +1255,7 @@ class ClientTest extends TestCase
      * @test
      *
      * @covers ::create
+     * @covers ::createWithUpload
      */
     public function it_creates_a_partial_resource_with_post_request() : void
     {
@@ -1450,6 +1452,7 @@ class ClientTest extends TestCase
      * @test
      *
      * @covers ::create
+     * @covers ::createWithUpload
      */
     public function it_throws_exception_when_unable_to_create_resource() : void
     {


### PR DESCRIPTION
TUS can transfer data already on resource creation (if creation-with-upload﻿ extension is enabled) see https://tus.io/protocols/resumable-upload.html#creation-with-upload﻿
the new function allows us to use that extension in the client
