### PR TITLE
chore: Run phpunit with XDEBUG_MODE=coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
 services:
   - redis
 
-script: ./vendor/bin/phpunit --coverage-clover=coverage.clover
+script: XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-clover=coverage.clover
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar


### PR DESCRIPTION
Some constants are only available in certain modes in Xdebug 3. This is fixed in the latest Xdebug release but not yet available in the version used by Travis. Also, it won't hurt to run xdebug in coverage mode.

See: https://github.com/xdebug/xdebug/pull/699