### PR TITLE
Lock the FileStore cache file when updating data

### DIFF
--- a/src/Cache/FileStore.php
+++ b/src/Cache/FileStore.php
@@ -143,14 +143,12 @@ class FileStore extends AbstractCache
      * @see LockedFileStore::lockedSet
      *
      * @deprecated It is not recommended to use this method, use `lockedSet` instead.
-     *
-
      */
-    public function put(string $path, string $contents): int
+    public function put(string $path, string $contents)
     {
         return $this->lockedSet(
             $path,
-            function ($data) use ($contents) {
+            function () use ($contents) {
                 return $contents;
             }
         );

--- a/src/Cache/FileStore.php
+++ b/src/Cache/FileStore.php
@@ -2,7 +2,6 @@
 
 namespace TusPhp\Cache;
 
-use TusPhp\File;
 use Carbon\Carbon;
 use TusPhp\Config;
 
@@ -36,7 +35,7 @@ class FileStore extends AbstractCache
      *
      * @return self
      */
-    public function setCacheDir(string $path) : self
+    public function setCacheDir(string $path): self
     {
         $this->cacheDir = $path;
 
@@ -48,7 +47,7 @@ class FileStore extends AbstractCache
      *
      * @return string
      */
-    public function getCacheDir() : string
+    public function getCacheDir(): string
     {
         return $this->cacheDir;
     }
@@ -60,7 +59,7 @@ class FileStore extends AbstractCache
      *
      * @return self
      */
-    public function setCacheFile(string $file) : self
+    public function setCacheFile(string $file): self
     {
         $this->cacheFile = $file;
 
@@ -72,7 +71,7 @@ class FileStore extends AbstractCache
      *
      * @return string
      */
-    public function getCacheFile() : string
+    public function getCacheFile(): string
     {
         return $this->cacheDir . $this->cacheFile;
     }
@@ -110,62 +109,51 @@ class FileStore extends AbstractCache
      */
     public function get(string $key, bool $withExpired = false)
     {
-        $key      = $this->getActualCacheKey($key);
-        $contents = $this->getCacheContents();
+        $key = $this->getActualCacheKey($key);
 
-        if (empty($contents[$key])) {
-            return null;
-        }
+        return $this->lockedGet(
+            $this->getCacheFile(),
+            false,
+            function ($handler, array $content) use ($withExpired, $key) {
+                if (empty($content[$key])) {
+                    return null;
+                }
 
-        if ($withExpired) {
-            return $contents[$key];
-        }
+                $meta = $content[$key];
 
-        return $this->isValid($key) ? $contents[$key] : null;
-    }
+                if ( ! $withExpired && ! $this->isValid($meta)) {
+                    return null;
+                }
 
-    /**
-     * Get contents of a file with shared access.
-     *
-     * @param string $path
-     *
-     * @return string
-     */
-    public function sharedGet(string $path) : string
-    {
-        $contents = '';
-        $handle   = @fopen($path, File::READ_BINARY);
-
-        if (false === $handle) {
-            return $contents;
-        }
-
-        try {
-            if (flock($handle, LOCK_SH)) {
-                clearstatcache(true, $path);
-
-                $contents = fread($handle, filesize($path) ?: 1);
-
-                flock($handle, LOCK_UN);
+                return $meta;
             }
-        } finally {
-            fclose($handle);
-        }
-
-        return $contents;
+        );
     }
 
     /**
      * Write the contents of a file with exclusive lock.
      *
+     * It is not recommended to use this method, for updating files as it will nullify any changes that have been made
+     * to the file between retrieving $contents and writing the changes. As such, one should instead use lockedSet.
+     *
      * @param string $path
      * @param string $contents
      *
-     * @return int
+     * @return int|bool
+     * @see LockedFileStore::lockedSet
+     *
+     * @deprecated It is not recommended to use this method, use `lockedSet` instead.
+     *
+
      */
-    public function put(string $path, string $contents) : int
+    public function put(string $path, string $contents): int
     {
-        return file_put_contents($path, $contents, LOCK_EX);
+        return $this->lockedSet(
+            $path,
+            function ($data) use ($contents) {
+                return $contents;
+            }
+        );
     }
 
     /**
@@ -176,36 +164,40 @@ class FileStore extends AbstractCache
         $cacheKey  = $this->getActualCacheKey($key);
         $cacheFile = $this->getCacheFile();
 
-        if ( ! file_exists($cacheFile) || ! $this->isValid($cacheKey)) {
+        if ( ! file_exists($cacheFile)) {
             $this->createCacheFile();
         }
 
-        $contents = json_decode($this->sharedGet($cacheFile), true) ?? [];
+        $this->lockedSet($cacheFile, function (array $data) use ($value, $cacheKey) {
+            if ( ! empty($data[$cacheKey]) && \is_array($value)) {
+                $data[$cacheKey] = $value + $data[$cacheKey];
+            } else {
+                $data[$cacheKey] = $value;
+            }
 
-        if ( ! empty($contents[$cacheKey]) && \is_array($value)) {
-            $contents[$cacheKey] = $value + $contents[$cacheKey];
-        } else {
-            $contents[$cacheKey] = $value;
-        }
-
-        return $this->put($cacheFile, json_encode($contents));
+            return $data;
+        });
     }
 
     /**
      * {@inheritDoc}
      */
-    public function delete(string $key) : bool
+    public function delete(string $key): bool
     {
         $cacheKey = $this->getActualCacheKey($key);
-        $contents = $this->getCacheContents();
+        $deletion = false;
 
-        if (isset($contents[$cacheKey])) {
-            unset($contents[$cacheKey]);
+        return $this->lockedSet(
+            $this->getCacheFile(),
+            function ($data) use ($cacheKey, &$deletion) {
+                    if (isset($data[$cacheKey])) {
+                        unset($data[$cacheKey]);
+                        $deletion = true;
+                    }
 
-            return false !== $this->put($this->getCacheFile(), json_encode($contents));
-        }
-
-        return false;
+                    return $data;
+                }
+        ) !== false && $deletion;
     }
 
     /**
@@ -225,14 +217,15 @@ class FileStore extends AbstractCache
     /**
      * Check if cache is still valid.
      *
-     * @param string $key
-     *
+     * @param string|array $meta The cache key, or the metadata object
      * @return bool
      */
-    public function isValid(string $key) : bool
+    public function isValid($meta): bool
     {
-        $key  = $this->getActualCacheKey($key);
-        $meta = $this->getCacheContents()[$key] ?? [];
+        if ( ! \is_array($meta)) {
+            $key  = $this->getActualCacheKey($meta);
+            $meta = $this->lockedGet($this->getCacheFile())[$key] ?? [];
+        }
 
         if (empty($meta['expires_at'])) {
             return false;
@@ -254,7 +247,7 @@ class FileStore extends AbstractCache
             return false;
         }
 
-        return json_decode($this->sharedGet($cacheFile), true) ?? [];
+        return $this->lockedGet($cacheFile);
     }
 
     /**
@@ -264,7 +257,7 @@ class FileStore extends AbstractCache
      *
      * @return string
      */
-    public function getActualCacheKey(string $key) : string
+    public function getActualCacheKey(string $key): string
     {
         $prefix = $this->getPrefix();
 
@@ -274,4 +267,129 @@ class FileStore extends AbstractCache
 
         return $key;
     }
+
+    //region File lock related operations
+
+    /**
+     * Acquire a lock on the given handle
+     *
+     * @param resource $handle
+     * @param int $lock The lock operation (`LOCK_SH`, `LOCK_EX`, or `LOCK_UN`)
+     * @param int $attempts The number of attempts before returning false
+     * @return bool True if the lock operation was successful
+     *
+     * @see LOCK_SH
+     * @see LOCK_EX
+     * @see LOCK_UN
+     */
+    protected function acquireLock($handle, int $lock, int $attempts = 5): bool
+    {
+        for ($i = 0; $i < $attempts; $i++) {
+            if (flock($handle, $lock)) {
+                return true;
+            }
+
+            usleep(100);
+        }
+
+        return false;
+    }
+
+    /**
+     * Get contents of a file with shared access.
+     *
+     * Example of the callable:
+     * ```php
+     * $property = function($handler, array $data) {
+     *      return $data['someProperty'];
+     * }
+     *
+     * // $property now has the contents of $data['someProperty']
+     * ```
+     *
+     * @param string $path
+     * @param bool $exclusive Whether we should use an exclusive or shared lock. If you are writing to the file, an
+     *  exclusive lock is recommended
+     * @param callable|null $callback The callable to call when we have locked the file. The first argument is the handle,
+     *  the second is an array with the cache contents. If left empty, a default callable will be used that returns the
+     *  data of the file
+     * @return mixed The output of the callable
+     */
+    public function lockedGet(string $path, bool $exclusive = false, ?callable $callback = null)
+    {
+        if ($callback === null) {
+            $callback = function ($handler, $data) {
+                return $data;
+            };
+        }
+
+        if ( ! file_exists($path)) {
+            $this->createCacheFile();
+        }
+
+        $handle = @fopen($path, 'r+b');
+        $lock   = $exclusive ? LOCK_EX : LOCK_SH;
+
+        if ($handle === false) {
+            return null;
+        }
+
+        try {
+            if ( ! $this->acquireLock($handle, $lock)) {
+                return null;
+            }
+
+            clearstatcache(true, $path);
+
+            $contents = fread($handle, filesize($path) ?: 1);
+
+            // Read the JSON data
+            $data = @json_decode($contents, true) ?? [];
+
+            return $callback($handle, $data);
+        } finally {
+            $this->acquireLock($handle, LOCK_UN);
+            fclose($handle);
+        }
+    }
+
+    /**
+     * Write contents to the given path while locking the file
+     *
+     * This locks the file during the callback: no other instances can read/modify the file while this operation is
+     * taking place. As such, one should use the data provided as an argument in the callback for modifying the file
+     * to prevent the loss of data.
+     *
+     * Example of the callable:
+     * ```php
+     * function(array $data) {
+     *     $data['someProperty'] = true;
+     *
+     *     return $data;
+     * }
+     * ```
+     *
+     * @param string $path The path of the file to write to
+     * @param callable $callback A callable for transforming the data. The first argument of the callable is the current
+     *  file contents, the return value will be the new contents (which will be json encoded if it is not a string
+     *  already)
+     * @return int|bool The amount of bytes that were written, or false if the write failed
+     */
+    public function lockedSet(string $path, callable $callback)
+    {
+        return $this->lockedGet($path, true, function ($handle, array $data) use ($callback) {
+            $data = $callback($data) ?? [];
+
+            ftruncate($handle, 0);
+            rewind($handle);
+
+            $data = \is_string($data) ? $data : json_encode($data);
+            $write = fwrite($handle, $data);
+
+            fflush($handle);
+
+            return $write;
+        });
+    }
+    //endregion
 }

--- a/src/Cache/FileStore.php
+++ b/src/Cache/FileStore.php
@@ -190,13 +190,13 @@ class FileStore extends AbstractCache
         return $this->lockedSet(
             $this->getCacheFile(),
             function ($data) use ($cacheKey, &$deletion) {
-                    if (isset($data[$cacheKey])) {
-                        unset($data[$cacheKey]);
-                        $deletion = true;
-                    }
-
-                    return $data;
+                if (isset($data[$cacheKey])) {
+                    unset($data[$cacheKey]);
+                    $deletion = true;
                 }
+
+                return $data;
+            }
         ) !== false && $deletion;
     }
 

--- a/tests/Cache/FileStoreTest.php
+++ b/tests/Cache/FileStoreTest.php
@@ -472,6 +472,29 @@ class FileStoreTest extends TestCase
     /**
      * @test
      *
+     * @covers ::acquireLock
+     */
+    public function it_file_is_locked()
+    {
+        $filePath  = __DIR__ . '/../.tmp/locked.json';
+        $fileStore = new FileStore(__DIR__ . '/../.tmp/', 'locked.json');
+        touch($filePath);
+
+        $handle = @fopen($filePath, 'r+b');
+        flock($handle, LOCK_EX);
+
+
+        $secondHandle = @fopen($filePath, 'r+b');
+        $this->assertFalse($fileStore->acquireLock($secondHandle, LOCK_EX | LOCK_NB));
+
+        flock($handle, LOCK_UN);
+        fclose($handle);
+        fclose($secondHandle);
+    }
+
+    /**
+     * @test
+     *
      * @covers ::lockedGet
      */
     public function it_gets_empty_contents_for_invalid_file_in_shared_get() : void

--- a/tests/Cache/FileStoreTest.php
+++ b/tests/Cache/FileStoreTest.php
@@ -158,7 +158,9 @@ class FileStoreTest extends TestCase
      * @covers ::isValid
      * @covers ::set
      * @covers ::get
-     * @covers ::put
+     * @covers ::acquireLock
+     * @covers ::lockedGet
+     * @covers ::lockedSet
      */
     public function it_sets_cache_contents() : void
     {
@@ -169,6 +171,31 @@ class FileStoreTest extends TestCase
         $this->assertFileExists($this->cacheDir);
         $this->assertFileExists($this->cacheDir.$this->cacheFile);
         $this->assertEquals($cacheContent, $this->fileStore->get($this->checksum));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::getCacheFile
+     * @covers ::createCacheFile
+     * @covers ::createCacheDir
+     * @covers ::isValid
+     * @covers ::get
+     * @covers ::put
+     * @covers ::acquireLock
+     * @covers ::lockedGet
+     */
+    public function it_put_cache_contents() : void
+    {
+        $cacheContent = ['expires_at' => 'Fri, 08 Dec 2017 16:25:51 GMT', 'offset' => 0];
+
+        $this->fileStore->put($this->fileStore->getCacheFile(), json_encode([
+            $this->fileStore->getActualCacheKey('test') => $cacheContent
+        ]));
+
+        $this->assertFileExists($this->cacheDir);
+        $this->assertFileExists($this->cacheDir.$this->cacheFile);
+        $this->assertEquals($cacheContent, $this->fileStore->get('test'));
     }
 
     /**

--- a/tests/Cache/FileStoreTest.php
+++ b/tests/Cache/FileStoreTest.php
@@ -319,7 +319,8 @@ class FileStoreTest extends TestCase
      * @covers ::set
      * @covers ::get
      * @covers ::getCacheContents
-     * @covers ::sharedGet
+     * @covers ::lockedGet
+     * @covers ::acquireLock
      */
     public function it_gets_all_cache_contents() : void
     {
@@ -342,8 +343,10 @@ class FileStoreTest extends TestCase
      * @covers ::set
      * @covers ::get
      * @covers ::delete
-     * @covers ::put
      * @covers ::getCacheContents
+     * @covers ::lockedGet
+     * @covers ::lockedSet
+     * @covers ::acquireLock
      */
     public function it_deletes_cache_content() : void
     {


### PR DESCRIPTION
Due to the implementation of the FileStore, some modifications of the cache file can be overwritten as described in issue #257. This pull request resolves the issue by keeping the cache file locked during the whole updates (instead of only portions of the update).

In the previous implementation, updating the cache file happened in the
following order:
1) File is locked;
2) Data is read;
3) File is unlocked;
4) Data is modified;
5) File is locked;
6) Data is written;
7) File is unlocked.

As you might imagine, it could happen that another process writes to the
file between reading (step 2) and writing (step 6). Since the cache
would simply overwrite the contents on a write, those changes would have
been nullified.

This caused problems with a large number of parallel uploads where the
offset would effectively been reverted (while the new data has been
appended), resulting in larger and corrupt files.

This new implementation rearranges the steps a bit to the following:
1) File is locked;
2) Data is read;
3) Data is modified;
4) Data is written;
5) File is unlocked.

Now, two processes can no longer interfere with one another and simply
have to wait. This means that the FileStore takes a small performance
hit, but given that the alternative is corrupt files, that is a
non-issue.

I did my best to keep the method signature of the FileStore as unchanged
as possible for backwards compatibility, but this does mean that there
are some unused (deprecated) methods in there now.

A small annoyance is that this behaviour is not easily reproducible (I have to brute-force it by dragging a large number of files around locally, hoping that the issue occurs). As such, testing this exact case in PHPUnit is rather difficult.