### PR TITLE
dev: Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
+SHELL := bash
 .PHONY: explain docker-build-base docker-build-base-php8 docker-build-server docker-build-client docker-build docker-build-php8 \
-		dev dev8 dev-clean dev-fresh dev8-fresh exec-server exec-client exec-redis deps lint lint-dry test test-coverage
+		dev dev8 dev-clean dev-fresh dev8-fresh exec-server exec-client exec-redis lint lint-dry test test-coverage
 
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
@@ -51,7 +52,7 @@ exec-redis:
 clean:
 	rm -rf composer.lock vendor/ coverage/ uploads/* .cache
 
-deps:
+vendor: composer.json $(wildcard composer.lock)
 	@composer install
 
 lint:
@@ -60,8 +61,8 @@ lint:
 lint-dry:
 	@bin/lint.sh dry
 
-test:
+test: vendor
 	@composer test
 
-test-coverage:
+test-coverage: vendor
 	@composer test-coverage

--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ If you are not using [make](https://www.gnu.org/software/make/manual/make.html#O
 1. Install [PHPUnit](https://phpunit.de/) and [composer](https://getcomposer.org/) if you haven't already.
 2. Install dependencies
      ```shell
-     $ make deps
+     $ make vendor
      
      # or
      


### PR DESCRIPTION
This PR modifies Makefile to:
- Add `SHELL` variable to specify default shell as `/bin/bash`
- Replace `deps` recipe with `vendor`

Note that the `vendor` recipe is not a `.PHONY` target anymore.
```sh
vendor: composer.json $(wildcard composer.lock)
```
The recipe above will compare the timestamp of the `vendor` directory with those of `composer.json` and `composer.lock` (if present), and will only execute the recipe if either of the composer files is newer than the vendor directory, or if the vendor directory is missing. Wildcard will make sure that Make command won't fail if `composer.lock` is absent.