### PR TITLE
fix: Align metadata extraction with protocol

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -145,7 +145,10 @@ class Request
         $uploadMetaDataChunks = explode(',', $uploadMetaData);
 
         foreach ($uploadMetaDataChunks as $chunk) {
-            [$key, $value] = explode(' ', $chunk);
+            $pieces = explode(' ', trim($chunk));
+
+            $key   = $pieces[0];
+            $value = $pieces[1] ?? '';
 
             if ($key === $requestedKey) {
                 return base64_decode($value);
@@ -172,7 +175,10 @@ class Request
 
         $result = [];
         foreach ($uploadMetaDataChunks as $chunk) {
-            [$key, $value] = explode(' ', $chunk);
+            $pieces = explode(' ', trim($chunk));
+
+            $key   = $pieces[0];
+            $value = $pieces[1] ?? '';
 
             $result[$key] = base64_decode($value);
         }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -2,9 +2,9 @@
 
 namespace TusPhp\Test;
 
-use TusPhp\Request;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use TusPhp\Request;
 
 /**
  * @coversDefaultClass \TusPhp\Request
@@ -209,7 +209,7 @@ class RequestTest extends TestCase
             ->set(
                 'Upload-Metadata',
                 sprintf(
-                    'filename %s,type %s,accept %s',
+                    'filename %s,type %s,noval, accept %s',
                     base64_encode($filename),
                     base64_encode($fileType),
                     base64_encode($accept)
@@ -219,7 +219,8 @@ class RequestTest extends TestCase
         $this->assertEquals($filename, $this->request->extractFileName());
         $this->assertEquals($fileType, $this->request->extractMeta('type'));
         $this->assertEquals($accept, $this->request->extractMeta('accept'));
-        $this->assertEquals(['filename' => $filename, 'type' => $fileType, 'accept' => $accept], $this->request->extractAllMeta());
+        $this->assertEquals('', $this->request->extractMeta('noval'));
+        $this->assertEquals(['filename' => $filename, 'type' => $fileType, 'noval' => '', 'accept' => $accept], $this->request->extractAllMeta());
     }
 
     /**

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -2,9 +2,9 @@
 
 namespace TusPhp\Test;
 
+use TusPhp\Request;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
-use TusPhp\Request;
 
 /**
  * @coversDefaultClass \TusPhp\Request


### PR DESCRIPTION
This PR make some changes on metadata extraction to align with the protocol.
- The value MAY be empty. In these cases, the space, which would normally separate the key and the value, MAY be left out.
- Even though the protocol doesn't say anything about empty space after comma and key, the official implementation seems to trim extra spaces.

Ref: https://tus.io/protocols/resumable-upload.html#upload-metadata

Fixes #378 