### PR TITLE
fix: Lock file on windows

### DIFF
--- a/src/Cache/FileStore.php
+++ b/src/Cache/FileStore.php
@@ -167,8 +167,8 @@ class FileStore extends AbstractCache
     public function sharedGet(string $path): string
     {
         return $this->lock($path, LOCK_SH, function ($handle) use ($path) {
-            $stat = fstat($handle);
-            $size = $stat ? $stat['size'] : 1;
+            $fstat = fstat($handle);
+            $size = $fstat ? $fstat['size'] : 1;
             $contents = fread($handle, $size ?: 1);
 
             if (false === $contents) {

--- a/src/Cache/FileStore.php
+++ b/src/Cache/FileStore.php
@@ -167,7 +167,7 @@ class FileStore extends AbstractCache
     public function sharedGet(string $path): string
     {
         return $this->lock($path, LOCK_SH, function ($handle) use ($path) {
-            $size = fstat($handle)["size"];
+            $size = fstat($handle)['size'];
             $contents = fread($handle, $size ?: 1);
 
             if (false === $contents) {
@@ -205,7 +205,7 @@ class FileStore extends AbstractCache
         }
 
         return $this->lock($cacheFile, LOCK_EX, function ($handle) use ($cacheKey, $cacheFile, $value) {
-            $size = fstat($handle)["size"];
+            $size = fstat($handle)['size'];
             $contents = fread($handle, $size ?: 1) ?? '';
             $contents = json_decode($contents, true) ?? [];
 

--- a/src/Cache/FileStore.php
+++ b/src/Cache/FileStore.php
@@ -167,7 +167,8 @@ class FileStore extends AbstractCache
     public function sharedGet(string $path): string
     {
         return $this->lock($path, LOCK_SH, function ($handle) use ($path) {
-            $size = fstat($handle)['size'];
+            $stat = fstat($handle);
+            $size = $stat ? $stat['size'] : 1;
             $contents = fread($handle, $size ?: 1);
 
             if (false === $contents) {

--- a/src/File.php
+++ b/src/File.php
@@ -22,6 +22,9 @@ class File
     /** @const Append binary mode */
     public const APPEND_BINARY = 'ab';
 
+    /** @const Read and write mode */
+    public const APPEND_WRITE = 'a+';
+
     /** @var string */
     protected $key;
 


### PR DESCRIPTION
On Windows write data that FileStore.php is programmed cause 
`Write of xx bytes failed with errno=13 Permission denied`
This is because the program call file_put_contents and filesize (that always return 0) methods on a locked file

From 14 PHPUnit test on Windows errors, on my implementation now have only 3 (that is non-related), this don't add any errors, only fix some existent errors