### PR TITLE
fix: do not pass null to json_decode()

### DIFF
--- a/src/Cache/RedisStore.php
+++ b/src/Cache/RedisStore.php
@@ -45,7 +45,9 @@ class RedisStore extends AbstractCache
         }
 
         $contents = $this->redis->get($key);
-        $contents = json_decode($contents, true);
+        if (null !== $contents) {
+            $contents = json_decode($contents, true);
+        }
 
         if ($withExpired) {
             return $contents;


### PR DESCRIPTION
Fixes:

```
json_decode(): Passing null to parameter #1 ($json) of type string is deprecated
```