### PR TITLE
Issue#414 Fix Location header behind HTTPS proxy

### DIFF
--- a/src/Tus/Server.php
+++ b/src/Tus/Server.php
@@ -366,7 +366,7 @@ class Server extends AbstractTus
         }
 
         $checksum = $this->getClientChecksum();
-        $location = $this->getRequest()->url() . $this->getApiPath() . '/' . $uploadKey;
+        $location = $this->getApiPath() . '/' . $uploadKey;
 
         $file = $this->buildFile([
             'name' => $fileName,


### PR DESCRIPTION
- Server.php behind HTTPS reverse proxy
- Stop assuming the FQDN in Location header in responses
- Rely upon ApiPath configuration instead
- Responds with relative URLs by default