### PR TITLE
Added Middleware Exception

### DIFF
--- a/src/Exception/MiddlewareException
+++ b/src/Exception/MiddlewareException
@@ -1,0 +1,7 @@
+<?php
+
+namespace TusPhp\Exception;
+
+class MiddlewareException extends \Exception
+{
+}

--- a/src/Tus/Server.php
+++ b/src/Tus/Server.php
@@ -16,6 +16,7 @@ use TusPhp\Middleware\Middleware;
 use TusPhp\Exception\FileException;
 use TusPhp\Exception\ConnectionException;
 use TusPhp\Exception\OutOfRangeException;
+use TusPhp\Exception\MiddlewareException;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\HttpFoundation\Response as HttpResponse;
@@ -255,7 +256,11 @@ class Server extends AbstractTus
      */
     public function serve()
     {
-        $this->applyMiddleware();
+        try {
+            $this->applyMiddleware();
+        } catch (MiddlewareException $e) {
+            return $this->response->send($e->getMessage(), $e->getCode());    
+        }
 
         $requestMethod = $this->getRequest()->method();
 


### PR DESCRIPTION
Currently there is no way to catch middleware exception on server serve function. This will help if someone creating custom middleware and want to hook it up in the main functionality. 