### PR TITLE
Drop support for PHP 7.*

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['8.0', '8.1', '8.2', '8.3']
+        php-version: ['8.1', '8.2', '8.3']
         composer-flags: ["--prefer-lowest --prefer-stable", ""]
       fail-fast: false
     services:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
     <a href="https://packagist.org/packages/ankitpokhrel/tus-php">
-        <img alt="PHP Version" src="https://img.shields.io/badge/php-7.2.5%2B-brightgreen.svg?style=flat-square" />
+        <img alt="PHP Version" src="https://img.shields.io/badge/php-8.1%2B-brightgreen.svg?style=flat-square" />
     </a>
     <a href="https://github.com/ankitpokhrel/tus-php/actions/workflows/ci.yml?query=branch%3Amain+is%3Acompleted">
         <img alt="Build Status" src="https://img.shields.io/github/actions/workflow/status/ankitpokhrel/tus-php/ci.yml?branch=main&style=flat-square" />
@@ -118,7 +118,7 @@ location ~ \.php$ {
     # ...
 
     fastcgi_request_buffering off; # Disable request buffering
-    
+
     # ...
 }
 ```
@@ -476,33 +476,33 @@ If you are not using [make](https://www.gnu.org/software/make/manual/make.html#O
 2. Install dependencies
      ```shell
      $ make vendor
-     
+
      # or
-     
+
      $ composer install
      ```
 3. Run tests with phpunit
     ```shell
     $ make test
-    
+
     # or
-    
+
     $ composer test
-    
+
     # or
-    
+
     $ ./vendor/bin/phpunit
     ```
 4. Validate changes against [PSR2 Coding Standards](http://www.php-fig.org/psr/psr-2/)
     ```shell
     # fix lint issues
     $ make lint
-    
+
     # dry run
     $ make lint-dry
     ```
 
-You can use `xdebug enable` and `xdebug disable` to enable and disable [Xdebug](https://xdebug.org/) inside the container. 
+You can use `xdebug enable` and `xdebug disable` to enable and disable [Xdebug](https://xdebug.org/) inside the container.
 
 ### Questions about this project?
 Please feel free to report any bug found. Pull requests, issues, and project recommendations are more than welcome!

--- a/composer.json
+++ b/composer.json
@@ -39,10 +39,7 @@
   },
   "config": {
     "optimize-autoloader": true,
-    "sort-packages": true,
-    "allow-plugins": {
-      "kylekatarnls/update-helper": true
-    }
+    "sort-packages": true
   },
   "scripts": {
     "test": "xdebug disable && vendor/bin/phpunit",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "authors": [
     {
-      "name": "Ankit P.",
+      "name": "Ankit Pokhrel",
       "email": "oss@ankit.pl"
     }
   ],

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "^8.0",
+    "php": "^8.1",
     "ext-json": "*",
     "guzzlehttp/guzzle": "^7.2",
     "nesbot/carbon": "^2.67 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "guzzlehttp/guzzle": "^7.2",
     "nesbot/carbon": "^2.67 || ^3.0",
     "predis/predis": "^2.0.3",
-    "ramsey/uuid": "^3.7 || ^4.0",
+    "ramsey/uuid": "^4.0",
     "symfony/console": "^6.0 || ^7.0",
     "symfony/event-dispatcher": "^6.0 || ^7.0",
     "symfony/http-foundation": "^6.0 || ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -5,27 +5,27 @@
   "license": "MIT",
   "authors": [
     {
-      "name": "Ankit Pokhrel",
-      "email": "hello@ankit.pl"
+      "name": "Ankit P.",
+      "email": "oss@ankit.pl"
     }
   ],
   "require": {
-    "php": "^7.2.5 || ^8.0",
+    "php": "^8.0",
     "ext-json": "*",
-    "guzzlehttp/guzzle": "^6.3 || ^7.0",
-    "nesbot/carbon": "^1.26.3 || ^2.0",
-    "predis/predis": "^1.1 || ^2.0",
+    "guzzlehttp/guzzle": "^7.2",
+    "nesbot/carbon": "^2.67 || ^3.0",
+    "predis/predis": "^2.0.3",
     "ramsey/uuid": "^3.7 || ^4.0",
-    "symfony/console": "^5.0 || ^6.0 || ^7.0",
-    "symfony/event-dispatcher": "^5.0 || ^6.0 || ^7.0",
-    "symfony/http-foundation": "^5.0.7 || ^6.0 || ^7.0",
-    "symfony/mime": "^5.0.9 || ^6.0 || ^7.0"
+    "symfony/console": "^6.0 || ^7.0",
+    "symfony/event-dispatcher": "^6.0 || ^7.0",
+    "symfony/http-foundation": "^6.0 || ^7.0",
+    "symfony/mime": "^6.0 || ^7.0"
   },
   "require-dev": {
     "ext-pcntl": "*",
     "friendsofphp/php-cs-fixer": "^3.0",
-    "mockery/mockery": "^1.3.4 || ^1.4.2",
-    "phpunit/phpunit": "^8.5.19 || ^10.0"
+    "mockery/mockery": "^1.4.2",
+    "phpunit/phpunit": "^10.5"
   },
   "autoload": {
     "psr-4": {
@@ -39,7 +39,10 @@
   },
   "config": {
     "optimize-autoloader": true,
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "kylekatarnls/update-helper": true
+    }
   },
   "scripts": {
     "test": "xdebug disable && vendor/bin/phpunit",


### PR DESCRIPTION
PHP `7.*` and `8.0` has already reached EOL, we won't support them from the next release.

https://www.php.net/supported-versions.php