### PR TITLE
chore(deps): add support for Symfony Console 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "nesbot/carbon": "^2.67 || ^3.0",
     "predis/predis": "^2.0.3",
     "ramsey/uuid": "^4.0",
-    "symfony/console": "^6.0 || ^7.0",
+    "symfony/console": "^6.0 || ^7.0 || ^8.0",
     "symfony/event-dispatcher": "^6.0 || ^7.0",
     "symfony/http-foundation": "^6.0 || ^7.0",
     "symfony/mime": "^6.0 || ^7.0"


### PR DESCRIPTION
This is required for Laravel 11.