### PR TITLE
Allow to pass an existing request object in constructor

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -13,10 +13,12 @@ class Request
     /**
      * Request constructor.
      */
-    public function __construct()
+    public function __construct(HttpRequest $request = null)
     {
-        if (null === $this->request) {
+        if (null === $request) {
             $this->request = HttpRequest::createFromGlobals();
+        } else {
+            $this->request = $request;
         }
     }
 

--- a/src/Tus/Server.php
+++ b/src/Tus/Server.php
@@ -80,9 +80,9 @@ class Server extends AbstractTus
      *
      * @throws \ReflectionException
      */
-    public function __construct($cacheAdapter = 'file')
+    public function __construct($cacheAdapter = 'file', HttpRequest $request = null)
     {
-        $this->request    = new Request();
+        $this->request    = new Request($request);
         $this->response   = new Response();
         $this->middleware = new Middleware();
         $this->uploadDir  = \dirname(__DIR__, 2) . '/' . 'uploads';

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -2,6 +2,7 @@
 
 namespace TusPhp\Test;
 
+use Mockery as m;
 use TusPhp\Request;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
@@ -24,6 +25,32 @@ class RequestTest extends TestCase
         $this->request = new Request();
 
         parent::setUp();
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     */
+    public function it_sets_and_gets_the_same_http_request(): void
+    {
+        $httpRequestMock = m::mock(HttpRequest::class);
+
+        $request = new Request($httpRequestMock);
+
+        $this->assertSame($httpRequestMock, $request->getRequest());
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     */
+    public function it_creates_the_http_request_when_passing_null(): void
+    {
+        $request = new Request(null);
+
+        $this->assertInstanceOf(HttpRequest::class, $request->getRequest());
     }
 
     /**

--- a/tests/Tus/ServerTest.php
+++ b/tests/Tus/ServerTest.php
@@ -21,6 +21,7 @@ use TusPhp\Middleware\GlobalHeaders;
 use TusPhp\Exception\ConnectionException;
 use TusPhp\Exception\OutOfRangeException;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\HttpFoundation\Response as HttpResponse;
 
 /**
@@ -106,6 +107,22 @@ class ServerTest extends TestCase
     public function it_gets_a_request(): void
     {
         $this->assertInstanceOf(Request::class, $this->tusServer->getRequest());
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::getRequest
+     */
+    public function it_sets_and_gets_the_same_http_request(): void
+    {
+        $httpRequestMock = m::mock(HttpRequest::class);
+
+        $tusServer = new TusServer('file', $httpRequestMock);
+
+        $this->assertInstanceOf(HttpRequest::class, $tusServer->getRequest()->getRequest());
+        $this->assertSame($httpRequestMock, $tusServer->getRequest()->getRequest());
     }
 
     /**
@@ -226,7 +243,7 @@ class ServerTest extends TestCase
             ->server
             ->set('REQUEST_METHOD', 'HEAD');
 
-        $requestMock = m::mock(Request::class, ['file'])->makePartial();
+        $requestMock = m::mock(Request::class, [null])->makePartial();
         $requestMock
             ->getRequest()
             ->headers
@@ -274,7 +291,7 @@ class ServerTest extends TestCase
             ->server
             ->set('REQUEST_METHOD', 'HEAD');
 
-        $requestMock = m::mock(Request::class, ['file'])->makePartial();
+        $requestMock = m::mock(Request::class, [null])->makePartial();
         $requestMock
             ->getRequest()
             ->headers
@@ -402,7 +419,7 @@ class ServerTest extends TestCase
 
         $tusServerMock->__construct('file');
 
-        $requestMock = m::mock(Request::class, ['file'])->makePartial();
+        $requestMock = m::mock(Request::class, [null])->makePartial();
         $requestMock
             ->getRequest()
             ->headers
@@ -804,7 +821,7 @@ class ServerTest extends TestCase
                 'REQUEST_URI' => '/files',
             ]);
 
-        $requestMock = m::mock(Request::class, ['file'])->makePartial();
+        $requestMock = m::mock(Request::class, [null])->makePartial();
         $requestMock
             ->getRequest()
             ->headers
@@ -854,7 +871,7 @@ class ServerTest extends TestCase
                 'REQUEST_URI' => '/files',
             ]);
 
-        $requestMock = m::mock(Request::class, ['file'])->makePartial();
+        $requestMock = m::mock(Request::class, [null])->makePartial();
         $requestMock
             ->getRequest()
             ->headers
@@ -916,7 +933,7 @@ class ServerTest extends TestCase
                 'REQUEST_URI' => '/files',
             ]);
 
-        $requestMock = m::mock(Request::class, ['file'])->makePartial();
+        $requestMock = m::mock(Request::class, [null])->makePartial();
         $requestMock
             ->getRequest()
             ->headers
@@ -1040,7 +1057,7 @@ class ServerTest extends TestCase
                 'REQUEST_URI' => '/files',
             ]);
 
-        $requestMock = m::mock(Request::class, ['file'])->makePartial();
+        $requestMock = m::mock(Request::class, [null])->makePartial();
         $requestMock
             ->getRequest()
             ->headers
@@ -1163,7 +1180,7 @@ class ServerTest extends TestCase
             'location' => $location,
         ];
 
-        $requestMock = m::mock(Request::class, ['file'])->makePartial();
+        $requestMock = m::mock(Request::class, [null])->makePartial();
         $requestMock
             ->getRequest()
             ->headers
@@ -1328,7 +1345,7 @@ class ServerTest extends TestCase
             ['file_path' => $filePath . 'file_b', 'offset' => 20],
         ];
 
-        $requestMock = m::mock(Request::class, ['file'])->makePartial();
+        $requestMock = m::mock(Request::class, [null])->makePartial();
         $requestMock
             ->getRequest()
             ->headers
@@ -3176,7 +3193,7 @@ class ServerTest extends TestCase
     {
         $this->assertTrue($this->tusServerMock->verifyUploadSize());
 
-        $requestMock = m::mock(Request::class, ['file'])->makePartial();
+        $requestMock = m::mock(Request::class, [null])->makePartial();
         $requestMock
             ->getRequest()
             ->headers


### PR DESCRIPTION
The current implementation always creates the HTTP request from the superglobals:

```php
public function __construct()
{
    if (null === $this->request) {
        $this->request = HttpRequest::createFromGlobals();
    }
}
```

But this is not always possible (e.g. when using [RoadRunner](https://roadrunner.dev/)). It's also an issue in combination with other frameworks (see #440).

With this pull request, users can pass their own Symfony HTTP request object in the constructor - if necessary.

Of course one could also extend the `Request` class and do the same. But this would also require extending the `Server` class.