### PR TITLE
Support injecting custom input-stream path

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -305,13 +305,13 @@ class File
      *
      * @return int
      */
-    public function upload(int $totalBytes): int
+    public function upload(int $totalBytes, ?string $inputFilePath = null): int
     {
         if ($this->offset === $totalBytes) {
             return $this->offset;
         }
 
-        $input  = $this->open($this->getInputStream(), self::READ_BINARY);
+        $input  = $this->open($inputFilePath ?? $this->getInputStream(), self::READ_BINARY);
         $output = $this->open($this->getFilePath(), self::APPEND_BINARY);
         $key    = $this->getKey();
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -11,6 +11,15 @@ class Request
     protected $request;
 
     /**
+     * Input-stream path
+     *
+     * Useful for php-http-servers (e.g. Swoole) that do not support php://input
+     *
+     * @var string|null
+     */
+    protected $requestStreamPath = null;
+
+    /**
      * Request constructor.
      */
     public function __construct()
@@ -224,6 +233,11 @@ class Request
     public function getRequest(): HttpRequest
     {
         return $this->request;
+    }
+
+    public function getStreamPath () : ?string
+    {
+        return $this->requestStreamPath;
     }
 
     /**

--- a/src/Tus/Server.php
+++ b/src/Tus/Server.php
@@ -470,7 +470,10 @@ class Server extends AbstractTus
 
         try {
             $fileSize = $file->getFileSize();
-            $offset   = $file->setKey($uploadKey)->setChecksum($checksum)->upload($fileSize);
+            $offset   = $file->setKey($uploadKey)->setChecksum($checksum)->upload(
+                $fileSize,
+                $this->request->getStreamPath()
+            );
 
             // If upload is done, verify checksum.
             if ($offset === $fileSize) {


### PR DESCRIPTION
Almost every flow is extendable except the path to input stream which was rigidly set to `php://input` as a class constant.

This update makes it possible to use a custom path to the input stream - the missing screw before i could fully implement with Swoole.