### PR TITLE
Add support for PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['8.1', '8.2', '8.3']
+        php-version: ['8.1', '8.2', '8.3', '8.4']
         composer-flags: ["--prefer-lowest --prefer-stable", ""]
       fail-fast: false
     services:
@@ -71,4 +71,4 @@ jobs:
           files: coverage.clover
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
-        if: matrix.php-version == '8.3'
+        if: matrix.php-version == '8.4'

--- a/src/Cache/FileStore.php
+++ b/src/Cache/FileStore.php
@@ -23,7 +23,7 @@ class FileStore extends AbstractCache
      * @param string|null $cacheDir
      * @param string|null $cacheFile
      */
-    public function __construct(string $cacheDir = null, string $cacheFile = null)
+    public function __construct(?string $cacheDir = null, ?string $cacheFile = null)
     {
         $cacheDir  = $cacheDir ?? Config::get('file.dir');
         $cacheFile = $cacheFile ?? Config::get('file.name');
@@ -134,7 +134,7 @@ class FileStore extends AbstractCache
      *
      * @return mixed
      */
-    protected function lock(string $path, int $type = LOCK_SH, callable $cb = null, $fopenType = FILE::READ_BINARY)
+    protected function lock(string $path, int $type = LOCK_SH, ?callable $cb = null, $fopenType = FILE::READ_BINARY)
     {
         $out    = false;
         $handle = @fopen($path, $fopenType);

--- a/src/Config.php
+++ b/src/Config.php
@@ -58,7 +58,7 @@ class Config
      *
      * @return mixed
      */
-    public static function get(string $key = null)
+    public static function get(?string $key = null)
     {
         self::set();
 

--- a/src/File.php
+++ b/src/File.php
@@ -505,7 +505,7 @@ class File
         $status = @copy($source, $destination);
 
         if (false === $status) {
-            throw new FileException(sprintf('Cannot copy source (%s) to destination (%s).', $source, $destination));
+            throw new FileException(\sprintf('Cannot copy source (%s) to destination (%s).', $source, $destination));
         }
 
         return $status;

--- a/src/File.php
+++ b/src/File.php
@@ -58,7 +58,7 @@ class File
      * @param string|null    $name
      * @param Cacheable|null $cache
      */
-    public function __construct(string $name = null, Cacheable $cache = null)
+    public function __construct(?string $name = null, ?Cacheable $cache = null)
     {
         $this->name  = $name;
         $this->cache = $cache;
@@ -74,7 +74,7 @@ class File
      *
      * @return File
      */
-    public function setMeta(int $offset, int $fileSize, string $filePath, string $location = null): self
+    public function setMeta(int $offset, int $fileSize, string $filePath, ?string $location = null): self
     {
         $this->offset   = $offset;
         $this->fileSize = $fileSize;

--- a/src/Response.php
+++ b/src/Response.php
@@ -114,7 +114,7 @@ class Response
      */
     public function download(
         $file,
-        string $name = null,
+        ?string $name = null,
         array $headers = [],
         string $disposition = ResponseHeaderBag::DISPOSITION_ATTACHMENT
     ): BinaryFileResponse {

--- a/src/Tus/Client.php
+++ b/src/Tus/Client.php
@@ -85,7 +85,7 @@ class Client extends AbstractTus
      *
      * @return Client
      */
-    public function file(string $file, string $name = null): self
+    public function file(string $file, ?string $name = null): self
     {
         $this->filePath = $file;
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -208,7 +208,7 @@ class RequestTest extends TestCase
             ->headers
             ->set(
                 'Upload-Metadata',
-                sprintf(
+                \sprintf(
                     'filename %s,type %s,noval, accept %s',
                     base64_encode($filename),
                     base64_encode($fileType),
@@ -314,7 +314,7 @@ class RequestTest extends TestCase
             ->headers
             ->set(
                 'Upload-Metadata',
-                sprintf(
+                \sprintf(
                     'filename %s,type %s,accept %s',
                     base64_encode($uploadMetadata['filename']),
                     base64_encode($uploadMetadata['type']),


### PR DESCRIPTION
Fixes the Explicit nullable param type deprecation warnings and upgrades the test suite to include PHP 8.4.