### PR TITLE
Client::sendHeadRequest: allow 204 status code

### DIFF
--- a/src/Tus/Client.php
+++ b/src/Tus/Client.php
@@ -594,7 +594,7 @@ class Client extends AbstractTus
         $response   = $this->getClient()->head($this->getUrl());
         $statusCode = $response->getStatusCode();
 
-        if (HttpResponse::HTTP_OK !== $statusCode) {
+        if (HttpResponse::HTTP_OK !== $statusCode || HttpResponse::HTTP_NO_CONTENT !== $statusCode) {
             throw new FileException('File not found.');
         }
 


### PR DESCRIPTION
From the [Tus 1.0.0 specification](https://tus.io/protocols/resumable-upload#head):

> The Server SHOULD acknowledge successful HEAD requests with a 200 OK or 204 No Content status.

The current implementation is being overly restrictive. In theory this is also only a SHOULD (so maybe a wider array of statuses should also be allowed), but this is at least an improvement.