### PR TITLE
Avoid a call to cache inside handlePost server method.

### DIFF
--- a/src/Tus/Server.php
+++ b/src/Tus/Server.php
@@ -376,11 +376,12 @@ class Server extends AbstractTus
             'location' => $location,
         ])->setKey($uploadKey)->setChecksum($checksum)->setUploadMetadata($this->getRequest()->extractAllMeta());
 
-        $this->cache->set($uploadKey, $file->details() + ['upload_type' => $uploadType]);
+        $cacheMetadata = $file->details() + ['upload_type' => $uploadType];
+        $this->cache->set($uploadKey, $cacheMetadata);
 
         $headers = [
             'Location' => $location,
-            'Upload-Expires' => $this->cache->get($uploadKey)['expires_at'],
+            'Upload-Expires' => $cacheMetadata['expires_at'],
         ];
 
         $this->event()->dispatch(


### PR DESCRIPTION
We are using this library in production and I just got a small error in our Sentry about the `expires_at` information not available.

I looked at the code and it seems that we are calling in the same method :

* cache->set
* cache->get

This PR is about removing the cache->get in that method because we were just building the information to be cached array.