### PR TITLE
overridable forbidden characters

### DIFF
--- a/src/Cache/FileStore.php
+++ b/src/Cache/FileStore.php
@@ -23,7 +23,7 @@ class FileStore extends AbstractCache
      * @param string|null $cacheDir
      * @param string|null $cacheFile
      */
-    public function __construct(string $cacheDir = null, string $cacheFile = null)
+    public function __construct(?string $cacheDir = null, ?string $cacheFile = null)
     {
         $cacheDir  = $cacheDir ?? Config::get('file.dir');
         $cacheFile = $cacheFile ?? Config::get('file.name');

--- a/src/Cache/FileStore.php
+++ b/src/Cache/FileStore.php
@@ -134,7 +134,7 @@ class FileStore extends AbstractCache
      *
      * @return mixed
      */
-    protected function lock(string $path, int $type = LOCK_SH, callable $cb = null, $fopenType = FILE::READ_BINARY)
+    protected function lock(string $path, int $type = LOCK_SH, ?callable $cb = null, $fopenType = FILE::READ_BINARY)
     {
         $out    = false;
         $handle = @fopen($path, $fopenType);

--- a/src/Config.php
+++ b/src/Config.php
@@ -58,7 +58,7 @@ class Config
      *
      * @return mixed
      */
-    public static function get(string $key = null)
+    public static function get(?string $key = null)
     {
         self::set();
 

--- a/src/File.php
+++ b/src/File.php
@@ -58,7 +58,7 @@ class File
      * @param string|null    $name
      * @param Cacheable|null $cache
      */
-    public function __construct(string $name = null, Cacheable $cache = null)
+    public function __construct(?string $name = null, ?Cacheable $cache = null)
     {
         $this->name  = $name;
         $this->cache = $cache;
@@ -74,7 +74,7 @@ class File
      *
      * @return File
      */
-    public function setMeta(int $offset, int $fileSize, string $filePath, string $location = null): self
+    public function setMeta(int $offset, int $fileSize, string $filePath, ?string $location = null): self
     {
         $this->offset   = $offset;
         $this->fileSize = $fileSize;

--- a/src/Request.php
+++ b/src/Request.php
@@ -235,7 +235,7 @@ class Request
      */
     protected function isValidFilename(string $filename): bool
     {
-        $forbidden = ['../', '"', "'", '&', '/', '\\', '?', '#', ':'];
+        $forbidden = Config::get('file.forbidden_characters') ?? ['../', '"', "'", '&', '/', '\\', '?', '#', ':'];
 
         foreach ($forbidden as $char) {
             if (false !== strpos($filename, $char)) {

--- a/src/Response.php
+++ b/src/Response.php
@@ -114,7 +114,7 @@ class Response
      */
     public function download(
         $file,
-        string $name = null,
+        ?string $name = null,
         array $headers = [],
         string $disposition = ResponseHeaderBag::DISPOSITION_ATTACHMENT
     ): BinaryFileResponse {

--- a/src/Tus/Client.php
+++ b/src/Tus/Client.php
@@ -85,7 +85,7 @@ class Client extends AbstractTus
      *
      * @return Client
      */
-    public function file(string $file, string $name = null): self
+    public function file(string $file, ?string $name = null): self
     {
         $this->filePath = $file;
 


### PR DESCRIPTION
Some forbidden characters are in fact not invalid on either Windows or Linux. At least, it’s debatable whether these should be restricted at the library level. For example, the "&" character is commonly used in filenames by our users, so as the least drastic change, I’ve made this forbidden character list optionally overridable. Since this is not mandatory, it doesn’t break any existing functionality.


Thank you for your work, consider merging this PR