### PR TITLE
Fix patch chunk race condition + overridable forbidden characters

### DIFF
--- a/src/Cache/FileStore.php
+++ b/src/Cache/FileStore.php
@@ -23,7 +23,7 @@ class FileStore extends AbstractCache
      * @param string|null $cacheDir
      * @param string|null $cacheFile
      */
-    public function __construct(string $cacheDir = null, string $cacheFile = null)
+    public function __construct(?string $cacheDir = null, ?string $cacheFile = null)
     {
         $cacheDir  = $cacheDir ?? Config::get('file.dir');
         $cacheFile = $cacheFile ?? Config::get('file.name');

--- a/src/Cache/FileStore.php
+++ b/src/Cache/FileStore.php
@@ -134,7 +134,7 @@ class FileStore extends AbstractCache
      *
      * @return mixed
      */
-    protected function lock(string $path, int $type = LOCK_SH, callable $cb = null, $fopenType = FILE::READ_BINARY)
+    protected function lock(string $path, int $type = LOCK_SH, ?callable $cb = null, $fopenType = FILE::READ_BINARY)
     {
         $out    = false;
         $handle = @fopen($path, $fopenType);

--- a/src/Config.php
+++ b/src/Config.php
@@ -58,7 +58,7 @@ class Config
      *
      * @return mixed
      */
-    public static function get(string $key = null)
+    public static function get(?string $key = null)
     {
         self::set();
 

--- a/src/File.php
+++ b/src/File.php
@@ -58,7 +58,7 @@ class File
      * @param string|null    $name
      * @param Cacheable|null $cache
      */
-    public function __construct(string $name = null, Cacheable $cache = null)
+    public function __construct(?string $name = null, ?Cacheable $cache = null)
     {
         $this->name  = $name;
         $this->cache = $cache;
@@ -74,7 +74,7 @@ class File
      *
      * @return File
      */
-    public function setMeta(int $offset, int $fileSize, string $filePath, string $location = null): self
+    public function setMeta(int $offset, int $fileSize, string $filePath, ?string $location = null): self
     {
         $this->offset   = $offset;
         $this->fileSize = $fileSize;

--- a/src/File.php
+++ b/src/File.php
@@ -22,6 +22,36 @@ class File
     /** @const Append binary mode */
     public const APPEND_BINARY = 'ab';
 
+    /**
+     * @const Open-for-read/write-without-truncating binary mode ('c+b'), used by upload() to
+     *        write chunks at a specific offset.
+     *
+     * This is NOT interchangeable with APPEND_BINARY. A file opened in append mode ('a'/'ab')
+     * ignores fseek() entirely - POSIX (and PHP, which just wraps the underlying C stdio append
+     * semantics) always writes appended data at the file's *current* end-of-file, no matter
+     * where the pointer was moved to. upload() used to open its destination with APPEND_BINARY
+     * and then call fseek($output, $this->offset) to resume a chunked upload at the right byte
+     * position - that seek was a silent no-op, and the code got away with it as long as chunks
+     * always arrived in order and exactly once.
+     *
+     * 'c+b' creates the file if it's missing (same as 'ab' would) and does not truncate an
+     * existing one, but it DOES honor fseek(), so a chunk actually lands at $this->offset
+     * instead of wherever the OS thinks the file currently ends.
+     *
+     * Why this mattered in practice: without a real seek, a stale/duplicate PATCH request for an
+     * upload (e.g. a client retry after a dropped response, racing with the original request that
+     * already went through - see Server::acquireUploadLock() for how that race is now also closed
+     * at the source) would get its bytes appended a second time *after* the legitimate data
+     * instead of overwriting the same offset. That is precisely how we found an extra, unaccounted
+     * for 8192-byte block (one File::CHUNK_SIZE) spliced into a real uploaded .mov file: the
+     * file's `mdat` box ended up declaring a size 8192 bytes short of where the trailing `moov`
+     * atom (the video's index/metadata) actually started on disk, so every parser (ffmpeg,
+     * ImageMagick, ...) read garbage where it expected the next box and reported the file as
+     * corrupt / missing its moov atom - even though the real moov data was still there, just
+     * offset by one duplicated chunk.
+     */
+    public const WRITE_BINARY = 'c+b';
+
     /** @const Read and write mode */
     public const APPEND_WRITE = 'a+';
 
@@ -312,7 +342,10 @@ class File
         }
 
         $input  = $this->open($this->getInputStream(), self::READ_BINARY);
-        $output = $this->open($this->getFilePath(), self::APPEND_BINARY);
+        // WRITE_BINARY (not APPEND_BINARY!) so the seek() below actually resumes at $this->offset
+        // instead of silently appending at the OS-reported end-of-file - see the WRITE_BINARY
+        // doc comment for the full story of the corruption this used to cause.
+        $output = $this->open($this->getFilePath(), self::WRITE_BINARY);
         $key    = $this->getKey();
 
         try {

--- a/src/Request.php
+++ b/src/Request.php
@@ -235,7 +235,7 @@ class Request
      */
     protected function isValidFilename(string $filename): bool
     {
-        $forbidden = ['../', '"', "'", '&', '/', '\\', '?', '#', ':'];
+        $forbidden = Config::get('file.forbidden_characters') ?? ['../', '"', "'", '&', '/', '\\', '?', '#', ':'];
 
         foreach ($forbidden as $char) {
             if (false !== strpos($filename, $char)) {

--- a/src/Response.php
+++ b/src/Response.php
@@ -114,7 +114,7 @@ class Response
      */
     public function download(
         $file,
-        string $name = null,
+        ?string $name = null,
         array $headers = [],
         string $disposition = ResponseHeaderBag::DISPOSITION_ATTACHMENT
     ): BinaryFileResponse {

--- a/src/Tus/Client.php
+++ b/src/Tus/Client.php
@@ -85,7 +85,7 @@ class Client extends AbstractTus
      *
      * @return Client
      */
-    public function file(string $file, string $name = null): self
+    public function file(string $file, ?string $name = null): self
     {
         $this->filePath = $file;
 

--- a/src/Tus/Server.php
+++ b/src/Tus/Server.php
@@ -455,6 +455,35 @@ class Server extends AbstractTus
     {
         $uploadKey = $this->request->key();
 
+        // --- Chunk-race fix, see doHandlePatch()/acquireUploadLock() for the full story. ---
+        // We wrap the whole PATCH handling in a per-uploadKey exclusive lock. Without this,
+        // a client-side retry (or two pods racing on the same shared upload volume) can send
+        // two PATCH requests for the *same* upload key before the first one has finished
+        // writing and has updated the cached offset. Both requests then read the same stale
+        // offset from the cache, both pass verifyPatchRequest()'s offset check, and both
+        // proceed to write their chunk. This is exactly how we lost 8192 bytes' worth of
+        // bookkeeping in a real uploaded .mov file: the file's `mdat` box ended up 8192 bytes
+        // (one CHUNK_SIZE, see File::CHUNK_SIZE) short of where the trailing `moov` atom
+        // actually started, because a duplicated chunk write got appended into the stream
+        // without the offset accounting ever knowing about it. Serializing PATCH handling per
+        // uploadKey turns a duplicate/retried request into a strictly sequential one: by the
+        // time it acquires the lock, it re-reads the (now up to date) cached offset, and
+        // verifyPatchRequest() correctly rejects it with 409 Conflict instead of letting it
+        // silently corrupt the file.
+        return $this->acquireUploadLock($uploadKey, function () use ($uploadKey) {
+            return $this->doHandlePatch($uploadKey);
+        });
+    }
+
+    /**
+     * Actual PATCH handling, run while holding the per-uploadKey lock acquired in handlePatch().
+     *
+     * @param string $uploadKey
+     *
+     * @return HttpResponse
+     */
+    protected function doHandlePatch(string $uploadKey): HttpResponse
+    {
         if ( ! $meta = $this->cache->get($uploadKey)) {
             return $this->response->send(null, HttpResponse::HTTP_GONE);
         }
@@ -505,6 +534,53 @@ class Server extends AbstractTus
             'Upload-Expires' => $meta['expires_at'],
             'Upload-Offset' => $offset,
         ]);
+    }
+
+    /**
+     * Run $callback while holding an exclusive, filesystem-based lock scoped to $uploadKey.
+     *
+     * Why this exists: tus-php ships with no coordination between concurrent PATCH requests
+     * for the same upload (see the history of this method for the corrupted-.mov incident that
+     * exposed it). $this->uploadDir is a volume shared between all app pods/containers on
+     * purpose (so any pod can serve any chunk of any upload), so a plain flock() on a lock file
+     * in that same shared directory is enough to serialize PATCH handling across processes *and*
+     * across pods - we don't need a separate distributed-lock backend (e.g. Redis) for this.
+     *
+     * @param string   $uploadKey
+     * @param callable $callback
+     *
+     * @return HttpResponse
+     */
+    protected function acquireUploadLock(string $uploadKey, callable $callback): HttpResponse
+    {
+        // Upload keys are normally uuid4 strings (see getUploadKey()), but they can also come
+        // straight from a client-supplied Upload-Key header, so we don't trust them as a
+        // filename as-is. Kept a single, flat lock directory (not one per uploadKey) so cleanup
+        // is trivial and we don't have to worry about the lock directory itself racing.
+        $lockFile = $this->uploadDir . '/.patch-lock-' . preg_replace('/[^A-Za-z0-9\-]/', '_', $uploadKey);
+
+        // Suppressed like File::open()'s fopen() call: a missing uploadDir (e.g. an upload that
+        // was never actually configured to write anywhere - some unit tests never set one) is
+        // handled explicitly right below, not something we want surfaced as a PHP warning.
+        $handle = @fopen($lockFile, 'c');
+
+        if (false === $handle) {
+            // If we can't even open a lock file, fail open rather than blocking uploads entirely -
+            // this mirrors the pre-fix behaviour (no locking) instead of introducing a new outage mode.
+            return $callback();
+        }
+
+        try {
+            // Blocking (LOCK_EX without LOCK_NB): a racing/retried request simply waits its turn
+            // instead of writing concurrently, which is exactly what turns the race into a safe,
+            // sequential retry (see the big comment in handlePatch() for why that matters).
+            flock($handle, LOCK_EX);
+
+            return $callback();
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+        }
     }
 
     /**

--- a/tests/FileTest.php
+++ b/tests/FileTest.php
@@ -344,6 +344,48 @@ class FileTest extends TestCase
     /**
      * @test
      *
+     * @covers ::open
+     * @covers ::seek
+     * @covers ::write
+     *
+     * Regression test for a real-world incident: an uploaded .mov file came out with an extra,
+     * unaccounted-for 8192-byte block spliced into its byte stream, right where a chunk boundary
+     * fell, which pushed its `moov` atom 8192 bytes further than the file's `mdat` box declared
+     * size accounted for - so every parser (ffmpeg, ImageMagick, ...) treated the file as
+     * corrupt / missing its moov atom. Root cause: upload() used to open its destination file in
+     * append mode (File::APPEND_BINARY = 'ab'), under which fseek() is a documented no-op - every
+     * write lands at the true end-of-file no matter where the pointer was moved to. So when a
+     * chunk PATCH got duplicated (client retry racing the original request, no locking in
+     * Server::handlePatch() at the time), both copies of the chunk got appended one after the
+     * other instead of the second one overwriting the first at the same offset.
+     *
+     * File::WRITE_BINARY ('c+b') fixes this: fseek() is honored, so writing to an offset that
+     * was already written just overwrites those bytes instead of growing the file. This test
+     * pins that behaviour down directly, independent of the write() retry logic itself.
+     */
+    public function it_overwrites_instead_of_appending_when_seeking_back_to_an_earlier_offset(): void
+    {
+        $file = __DIR__ . '/.tmp/upload.txt';
+
+        $handle = $this->file->open($file, File::WRITE_BINARY);
+        $this->file->write($handle, 'AAAAABBBBBBBBBBBBBBB'); // 5 + 15 = 20 bytes total.
+        $this->file->close($handle);
+
+        // Simulate a duplicated/retried PATCH for the chunk covering bytes [5, 10).
+        $handle = $this->file->open($file, File::WRITE_BINARY);
+        $this->file->seek($handle, 5);
+        $this->file->write($handle, 'XXXXX');
+        $this->file->close($handle);
+
+        $this->assertEquals(20, filesize($file));
+        $this->assertEquals('AAAAAXXXXXBBBBBBBBBB', file_get_contents($file));
+
+        @unlink($file);
+    }
+
+    /**
+     * @test
+     *
      * @covers ::merge
      */
     public function it_throws_file_exception_if_file_to_merge_doesnt_exist(): void


### PR DESCRIPTION
forbidden characters should be overridden.

patch retry (on http reverse proxy) can cause upload corruption, because fseek is not working with append. fix is in the fopen parameter, and a file write lock is implemented to mitigate problems because of race conditions also.

also php deprecation error fixes in some places.