### PR TITLE
fix: Guard against race condition in FileStore::createCacheDir

### DIFF
--- a/src/Cache/FileStore.php
+++ b/src/Cache/FileStore.php
@@ -87,8 +87,9 @@ class FileStore extends AbstractCache
      */
     protected function createCacheDir()
     {
-        if ( ! file_exists($this->cacheDir)) {
-            mkdir($this->cacheDir);
+        if ( ! is_dir($this->cacheDir)) {
+            // Suppress "File exists" warning when a concurrent request wins the race.
+            @mkdir($this->cacheDir, 0777, true);
         }
     }
 

--- a/tests/Cache/FileStoreTest.php
+++ b/tests/Cache/FileStoreTest.php
@@ -152,6 +152,28 @@ class FileStoreTest extends TestCase
     /**
      * @test
      *
+     * @covers ::createCacheFile
+     * @covers ::createCacheDir
+     */
+    public function it_creates_nested_cache_dir_recursively(): void
+    {
+        $nestedDir = Config::get('file.dir') . 'nested' . DS . 'cache' . DS;
+        $cacheFile = Config::get('file.name');
+        $fileStore = new FileStore($nestedDir, $cacheFile);
+
+        $fileStore->set($this->checksum, 'Test');
+
+        $this->assertDirectoryExists($nestedDir);
+        $this->assertFileExists($nestedDir . $cacheFile);
+
+        unlink($nestedDir . $cacheFile);
+        rmdir($nestedDir);
+        rmdir(\dirname($nestedDir));
+    }
+
+    /**
+     * @test
+     *
      * @covers ::getCacheFile
      * @covers ::createCacheFile
      * @covers ::createCacheDir


### PR DESCRIPTION
### Problem

Under concurrent uploads, `FileStore::createCacheDir()` can crash with `mkdir(): File exists`. On PHP setups that promote warnings to exceptions (e.g. Laravel's error handler), this surfaces as a fatal `ErrorException` on the first upload after the cache directory is absent.

### Root cause

The check-then-create is not atomic:

```php
if ( ! file_exists($this->cacheDir)) {
    mkdir($this->cacheDir);
}
```

Two concurrent requests can both pass `file_exists()`, then both call `mkdir()`; the loser gets a `File exists` warning.

Note: this is a different race from the cache-file data race fixed previously (#366, #368) - those hardened reads/writes of the cache *file*, whereas this fixes creation of the cache *directory* itself.

### Fix

- Suppress the race-loser warning with `@mkdir()`; the directory ends up existing either way.
- Use `is_dir()` (the correct predicate - `file_exists()` is also true for a file at that path).
- Create recursively (`0777, true`) so nested cache paths work; default mode is unchanged.

### Testing

Added `it_creates_nested_cache_dir_recursively`, which fails on `main` and passes with the fix. Full suite stays green.

A pure concurrency race can't be reproduced deterministically in a single-threaded test; the added test covers the recursive-creation half, and the warning suppression is the standard idiom used by Symfony/Laravel `mkdir` helpers.
